### PR TITLE
Adicioanndo espera no testes para evitar falha

### DIFF
--- a/teste/SME.SGP.Integracao.Teste/TipoCalendarioTeste.cs
+++ b/teste/SME.SGP.Integracao.Teste/TipoCalendarioTeste.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -56,6 +57,9 @@ namespace SME.SGP.Integracao.Teste
                     var filtroFeriadoCalendarioDto = new FiltroFeriadoCalendarioDto() { Tipo = Dominio.TipoFeriadoCalendario.Movel, Ano = 2019 };
 
                     var jsonParaPostFiltroFeriados = new StringContent(TransformarEmJson(filtroFeriadoCalendarioDto), Encoding.UTF8, "application/json");
+
+                    Thread.Sleep(2000);
+
                     var postResultBuscaFeriados = await _fixture._clientApi.PostAsync("api/v1/calendarios/feriados/listar", jsonParaPostFiltroFeriados);
 
                     Assert.True(postResultBuscaFeriados.IsSuccessStatusCode);


### PR DESCRIPTION
Adicionando espera no teste para evitar de listar os feriados moveis antes do metodo async cadastrar

[AB#7730](https://dev.azure.com/amcomgov/c1dcf343-60ee-40b6-a30a-3b9c12c6d220/_workitems/edit/7730)