### PR TITLE
fix/7685 : Status das notificações Incorreto

### DIFF
--- a/src/SME.SGP.WebClient/src/paginas/Principal/listaNotificacoes.js
+++ b/src/SME.SGP.WebClient/src/paginas/Principal/listaNotificacoes.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import styled from 'styled-components';
 import * as moment from 'moment';
@@ -6,8 +6,14 @@ import DataTable from '~/componentes/table/dataTable';
 import { Colors } from '~/componentes/colors';
 import Button from '~/componentes/button';
 import history from '~/servicos/history';
+import servicoNotificacao from '~/servicos/Paginas/ServicoNotificacao';
 
 const ListaNotificacoes = () => {
+  const usuario = useSelector(state => state.usuario);
+  
+  useEffect(()=>{
+    servicoNotificacao.buscaNotificacoesPorAnoRf(2019, usuario.rf);
+  },[]);
   const notificacoes = useSelector(state => state.notificacoes);
 
   const categoriaLista = ['', 'Alerta', 'Ação', 'Aviso'];


### PR DESCRIPTION
**Problema**
Ao acessar o sistema com notificações pendentes e trocar seu status, quando retorna ao dashboard a mesma continua no status inicial.
Problema ocorre com o dashboard e pop-up de notificações

**Causa**
Utilizado Redux para cachear as notificações e tanto o dashboard quanto o pop-up carregam as Notificações do cache.

**Solução**
Na renderização da lista de notificações do dashboard foi chamado o metodo para consulta das notificações no backend e atualização do cache. Corrigindo assim também os status no pop-up.

[AB#6446](https://dev.azure.com/amcomgov/Novo%20SGP/_workitems/edit/6446)