### PR TITLE
Inclusão de permissão no endpoint de Tipo de calendario 

### DIFF
--- a/src/SME.SGP.Api/Controllers/TipoCalendarioController.cs
+++ b/src/SME.SGP.Api/Controllers/TipoCalendarioController.cs
@@ -27,7 +27,7 @@ namespace SME.SGP.Api.Controllers
         [HttpGet]
         [ProducesResponseType(typeof(IEnumerable<TipoCalendarioDto>), 200)]
         [ProducesResponseType(typeof(RetornoBaseDto), 500)]
-        [Permissao(Permissao.TCE_C, Policy = "Bearer")]
+        [Permissao(Permissao.TCE_C, Permissao.E_C, Policy = "Bearer")]
         public IActionResult BuscarTodos()
         {
             return Ok(consultas.Listar());


### PR DESCRIPTION
Inclusão de permissão no endpoint de Tipo de calendario  para usuários que podem acessar a tela de eventos.

Esse pullRequest contempla as seguintes alterações

- [ ] Inclui uma nova permissão na listagem de tipo de calendario para usuarios que podem acessar a tela de eventos

[AB#7813](https://dev.azure.com/amcomgov/c1dcf343-60ee-40b6-a30a-3b9c12c6d220/_workitems/edit/7813)