### PR TITLE
Correção

### DIFF
--- a/src/SME.SGP.Dominio.Servicos/ServicoEvento.cs
+++ b/src/SME.SGP.Dominio.Servicos/ServicoEvento.cs
@@ -79,6 +79,8 @@ namespace SME.SGP.Dominio.Servicos
 
             await VerificaParticularidadesSME(evento, usuario, periodos, dataConfirmada);
 
+            AtribuirNullSeVazio(evento);
+
             repositorioEvento.Salvar(evento);
 
             await AlterarRecorrenciaEventos(evento, alterarRecorrenciaCompleta);
@@ -138,6 +140,15 @@ namespace SME.SGP.Dominio.Servicos
             }
             var usuarioLogado = await servicoUsuario.ObterUsuarioLogado();
             EnviarNotificacaoRegistroDeRecorrencia(evento, notificacoesSucesso, notificacoesFalha, usuarioLogado.Id);
+        }
+
+        private static void AtribuirNullSeVazio(Evento evento)
+        {
+            if (string.IsNullOrWhiteSpace(evento.DreId))
+                evento.DreId = null;
+
+            if (string.IsNullOrWhiteSpace(evento.UeId))
+                evento.UeId = null;
         }
 
         private Evento AlterarEventoDeRecorrencia(Evento evento, Evento eventoASerAlterado)

--- a/src/SME.SGP.WebClient/public/configuracoes/variaveis.json
+++ b/src/SME.SGP.WebClient/public/configuracoes/variaveis.json
@@ -1,3 +1,3 @@
 {
-  "API_URL": "http://dev.integracao.sme.prefeitura.sp.gov.br/api"
+  "API_URL": "https://localhost:5001/api"
 }


### PR DESCRIPTION
Este pull request contempla a seguinte correção:

- [ ] Salvar a id da dre e da ue como nulo quando vierem vazios do front

[AB#8288](https://dev.azure.com/amcomgov/c1dcf343-60ee-40b6-a30a-3b9c12c6d220/_workitems/edit/8288)