### PR TITLE
7919 - Consistencia da grade no cadastro de aula

### DIFF
--- a/src/SME.SGP.Dados/Repositorios/RepositorioAula.cs
+++ b/src/SME.SGP.Dados/Repositorios/RepositorioAula.cs
@@ -19,7 +19,8 @@ namespace SME.SGP.Dados.Repositorios
         {
             var query = @"select professor_id, quantidade, data_aula 
                  from aula 
-                where turma_id = @turma 
+                where not excluido 
+                  and turma_id = @turma 
                   and disciplina_id = @disciplina";
 
             return await database.Conexao.QueryAsync<AulasPorTurmaDisciplinaDto>(query, new

--- a/src/SME.SGP.Dominio.Servicos/ServicoAula.cs
+++ b/src/SME.SGP.Dominio.Servicos/ServicoAula.cs
@@ -1,4 +1,5 @@
-﻿using SME.SGP.Aplicacao.Integracoes;
+﻿using SME.SGP.Aplicacao;
+using SME.SGP.Aplicacao.Integracoes;
 using SME.SGP.Dominio.Interfaces;
 using System.Linq;
 using System.Threading.Tasks;
@@ -11,16 +12,19 @@ namespace SME.SGP.Dominio.Servicos
         private readonly IRepositorioTipoCalendario repositorioTipoCalendario;
         private readonly IServicoDiaLetivo servicoDiaLetivo;
         private readonly IServicoEOL servicoEOL;
+        private readonly IConsultasGrade consultasGrade;
 
         public ServicoAula(IRepositorioAula repositorioAula,
                            IServicoEOL servicoEOL,
                            IRepositorioTipoCalendario repositorioTipoCalendario,
-                           IServicoDiaLetivo servicoDiaLetivo)
+                           IServicoDiaLetivo servicoDiaLetivo,
+                           IConsultasGrade consultasGrade)
         {
             this.repositorioAula = repositorioAula ?? throw new System.ArgumentNullException(nameof(repositorioAula));
             this.servicoEOL = servicoEOL ?? throw new System.ArgumentNullException(nameof(servicoEOL));
             this.repositorioTipoCalendario = repositorioTipoCalendario ?? throw new System.ArgumentNullException(nameof(repositorioTipoCalendario));
             this.servicoDiaLetivo = servicoDiaLetivo ?? throw new System.ArgumentNullException(nameof(servicoDiaLetivo));
+            this.consultasGrade = consultasGrade ?? throw new System.ArgumentNullException(nameof(consultasGrade));
         }
 
         public async Task Salvar(Aula aula, Usuario usuario)
@@ -42,6 +46,10 @@ namespace SME.SGP.Dominio.Servicos
             {
                 throw new NegocioException("Não é possível cadastrar essa aula pois a data informada está fora do período letivo.");
             }
+
+            var gradeAulas = await consultasGrade.ObterGradeAulasTurma(int.Parse(aula.TurmaId), int.Parse(aula.DisciplinaId));
+            if ((gradeAulas != null) && (gradeAulas.QuantidadeAulasRestante < aula.Quantidade))
+                throw new NegocioException("Quantidade de aulas superior ao limíte de aulas da grade.");
 
             repositorioAula.Salvar(aula);
         }

--- a/src/SME.SGP.Dominio/Enumerados/TipoEscola.cs
+++ b/src/SME.SGP.Dominio/Enumerados/TipoEscola.cs
@@ -8,7 +8,7 @@ namespace SME.SGP.Dominio
     public enum TipoEscola
     {
         [Display(Name = "Não Informado", ShortName = "NA")]
-        Nenhum = 1,
+        Nenhum = 0,
 
         [Display(Name = "Escola Municipal de Ensino Fundamental", ShortName = "EMEF")]
         EMEF = 1,

--- a/teste/SME.SGP.Aplicacao.Teste/Comandos/ComandosEventoTipoTeste.cs
+++ b/teste/SME.SGP.Aplicacao.Teste/Comandos/ComandosEventoTipoTeste.cs
@@ -1,5 +1,4 @@
 ﻿using Moq;
-using SME.SGP.Aplicacao.Interfaces;
 using SME.SGP.Dominio;
 using SME.SGP.Dominio.Entidades;
 using SME.SGP.Dominio.Interfaces;

--- a/teste/SME.SGP.Aplicacao.Teste/Consultas/ConsultasEventoTipoTeste.cs
+++ b/teste/SME.SGP.Aplicacao.Teste/Consultas/ConsultasEventoTipoTeste.cs
@@ -1,6 +1,5 @@
 ﻿using Microsoft.AspNetCore.Http;
 using Moq;
-using SME.SGP.Aplicacao.Interfaces;
 using SME.SGP.Dominio;
 using SME.SGP.Dominio.Entidades;
 using SME.SGP.Dominio.Interfaces;

--- a/teste/SME.SGP.Aplicacao.Teste/Consultas/ConsultasGradeTeste.cs
+++ b/teste/SME.SGP.Aplicacao.Teste/Consultas/ConsultasGradeTeste.cs
@@ -13,14 +13,16 @@ namespace SME.SGP.Aplicacao.Teste.Consultas
     {
         private readonly ConsultasGrade consultasGrade;
         private readonly Mock<IRepositorioGrade> repositorioGrade;
-        private readonly Mock<IServicoUsuario> servicoUsuario;
+        private readonly Mock<IConsultasAbrangencia> consultasAbrangencia;
+        private readonly Mock<IConsultasAula> consultasAula;
 
         public ConsultasGradeTeste()
         {
             repositorioGrade = new Mock<IRepositorioGrade>();
-            servicoUsuario = new Mock<IServicoUsuario>();
+            consultasAbrangencia = new Mock<IConsultasAbrangencia>();
+            consultasAula = new Mock<IConsultasAula>();
 
-            consultasGrade = new ConsultasGrade(repositorioGrade.Object, servicoUsuario.Object);
+            consultasGrade = new ConsultasGrade(repositorioGrade.Object, consultasAbrangencia.Object, consultasAula.Object);
 
             Setup();
         }

--- a/teste/SME.SGP.Aplicacao.Teste/Consultas/ConsultasPeriodoEscolarTeste.cs
+++ b/teste/SME.SGP.Aplicacao.Teste/Consultas/ConsultasPeriodoEscolarTeste.cs
@@ -1,6 +1,5 @@
 ﻿using Moq;
 using SME.SGP.Aplicacao.Consultas;
-using SME.SGP.Aplicacao.Interfaces;
 using SME.SGP.Dominio;
 using SME.SGP.Dominio.Interfaces;
 using System;


### PR DESCRIPTION
Ao incluir uma aula a grade deve ser consultada para que não seja cadastrado mais aulas do que o permitido pela grade;

[AB#6983](https://dev.azure.com/amcomgov/Novo%20SGP/_workitems/edit/6983)
