### PR TITLE
8159 - Retorno dos Objetivos no plano aula

### DIFF
--- a/src/SME.SGP.Api/Controllers/PlanoAulaController.cs
+++ b/src/SME.SGP.Api/Controllers/PlanoAulaController.cs
@@ -20,7 +20,7 @@ namespace SME.SGP.Api.Controllers
             [FromServices] IConsultasPlanoAula consultas)
         {
             // Data Escola Turma Dis
-            var planoDto = await consultas.ObterPlanoAulaPorTurmaDisciplina(aulaId);
+            var planoDto = await consultas.ObterPlanoAulaPorAula(aulaId);
 
             if (planoDto != null)
                 return Ok(planoDto);

--- a/src/SME.SGP.Aplicacao/Interfaces/Consultas/IConsultasPlanoAula.cs
+++ b/src/SME.SGP.Aplicacao/Interfaces/Consultas/IConsultasPlanoAula.cs
@@ -8,6 +8,6 @@ namespace SME.SGP.Aplicacao
 {
     public interface IConsultasPlanoAula
     {
-        Task<PlanoAulaRetornoDto> ObterPlanoAulaPorTurmaDisciplina(long aulaId);
+        Task<PlanoAulaRetornoDto> ObterPlanoAulaPorAula(long aulaId);
     }
 }

--- a/src/SME.SGP.Infra/Dtos/PlanoAulaRetornoDto.cs
+++ b/src/SME.SGP.Infra/Dtos/PlanoAulaRetornoDto.cs
@@ -7,7 +7,7 @@ namespace SME.SGP.Infra
     {
         public PlanoAulaRetornoDto()
         {
-            ObjetivosAprendizagemAula = new List<long>();
+            ObjetivosAprendizagemAula = new List<ObjetivoAprendizagemDto>();
         }
 
         public long Id { get; set; }
@@ -18,6 +18,6 @@ namespace SME.SGP.Infra
         public long AulaId { get; set; }
         public int QtdAulas { get; set; }
 
-        public List<long> ObjetivosAprendizagemAula { get; set; }
+        public List<ObjetivoAprendizagemDto> ObjetivosAprendizagemAula { get; set; }
     }
 }

--- a/teste/SME.SGP.Aplicacao.Teste/Consultas/ConsultasPlanoAulaTeste.cs
+++ b/teste/SME.SGP.Aplicacao.Teste/Consultas/ConsultasPlanoAulaTeste.cs
@@ -77,7 +77,7 @@ namespace SME.SGP.Aplicacao.Teste.Consultas
         public async void Deve_Obter_Por_Turma_Disciplina()
         {
             // ACT
-            var planoAula = await consultasPlanoAula.ObterPlanoAulaPorTurmaDisciplina(1);
+            var planoAula = await consultasPlanoAula.ObterPlanoAulaPorAula(1);
 
             // ASSERT
             Assert.False(planoAula == null);


### PR DESCRIPTION
Alterado retorno dos objetivos no plano aula;
Anteriormente era retornado apenas os IDs dos objetivos anuais selecionados para a aula, para que o front filtrasse na lista de objetivos anuais e mostrasse os objetivos da aula;

Verificado que a interação no front não ficaria boa pois os objetivos anuais são carregados apenas das disciplinas selecionadas na tag, então foi incluso o Dto completo dos objetivos selecionados na aula para retorno ao front facilitando a montagem dos objetivos selecionados;

[AB#4507](https://dev.azure.com/amcomgov/Novo%20SGP/_workitems/edit/4507)