### PR TITLE
8159 - Filtro dos objetivos pelo Id do Jurema

### DIFF
--- a/src/SME.SGP.Aplicacao/Comandos/ComandosPlanoAula.cs
+++ b/src/SME.SGP.Aplicacao/Comandos/ComandosPlanoAula.cs
@@ -13,6 +13,8 @@ namespace SME.SGP.Aplicacao
         private readonly IRepositorioObjetivoAprendizagemAula repositorioObjetivosAula;
         private readonly IRepositorioAula repositorioAula;
         private readonly IConsultasAbrangencia consultasAbrangencia;
+        private readonly IConsultasObjetivoAprendizagem consultasObjetivosPlanoAnual;
+        private readonly IConsultasPlanoAnual consultasPlanoAnual;
         private readonly IServicoUsuario servicoUsuario;
         private readonly IUnitOfWork unitOfWork;
 
@@ -20,6 +22,8 @@ namespace SME.SGP.Aplicacao
                         IRepositorioObjetivoAprendizagemAula repositorioObjetivosAula,
                         IRepositorioAula repositorioAula,
                         IConsultasAbrangencia consultasAbrangencia,
+                        IConsultasObjetivoAprendizagem consultasObjetivosPlanoAnual,
+                        IConsultasPlanoAnual consultasPlanoAnual,
                         IServicoUsuario servicoUsuario,
                         IUnitOfWork unitOfWork)
         {
@@ -27,6 +31,8 @@ namespace SME.SGP.Aplicacao
             this.repositorioObjetivosAula = repositorioObjetivosAula;
             this.repositorioAula = repositorioAula;
             this.consultasAbrangencia = consultasAbrangencia;
+            this.consultasObjetivosPlanoAnual = consultasObjetivosPlanoAnual;
+            this.consultasPlanoAnual = consultasPlanoAnual;
             this.unitOfWork = unitOfWork;
             this.servicoUsuario = servicoUsuario;
         }
@@ -42,7 +48,7 @@ namespace SME.SGP.Aplicacao
             PlanoAula planoAula = await repositorio.ObterPlanoAulaPorAula(planoAulaDto.AulaId);
             planoAula = MapearParaDominio(planoAulaDto, planoAula);
 
-            if (planoAulaDto.ObjetivosAprendizagemAula == null || !planoAulaDto.ObjetivosAprendizagemAula.Any())
+            if (planoAulaDto.ObjetivosAprendizagemJurema == null || !planoAulaDto.ObjetivosAprendizagemJurema.Any())
             {
                 var permitePlanoSemObjetivos = false;
 
@@ -67,19 +73,22 @@ namespace SME.SGP.Aplicacao
                     throw new NegocioException("A seleção de objetivos de aprendizagem é obrigatória para criação do plano de aula");
             }
 
+            var bimestre = (aula.DataAula.Month + 2) / 3;
+            var planoAnualId = await consultasPlanoAnual.ObterIdPlanoAnualPorAnoEscolaBimestreETurma(
+                        aula.DataAula.Year, aula.UeId, long.Parse(aula.TurmaId), bimestre, long.Parse(aula.DisciplinaId));
+
             using (var transacao = unitOfWork.IniciarTransacao())
             {
                 repositorio.Salvar(planoAula);
                 // Salvar Objetivos
                 await repositorioObjetivosAula.LimparObjetivosAula(planoAula.Id);
-                if (planoAulaDto.ObjetivosAprendizagemAula != null)
-                    foreach (var objetivoAprendizagem in planoAulaDto.ObjetivosAprendizagemAula)
+                if (planoAulaDto.ObjetivosAprendizagemJurema != null)
+                    foreach(var objetivoJuremaId in planoAulaDto.ObjetivosAprendizagemJurema)
                     {
-                        planoAulaDto.ObjetivosAprendizagemAula.ForEach(objetivoId =>
-                        {
-                            repositorioObjetivosAula.Salvar(new ObjetivoAprendizagemAula(planoAula.Id, objetivoId));
-                        });
+                        var objetivoPlanoAnualId = await consultasObjetivosPlanoAnual
+                                .ObterIdPorObjetivoAprendizagemJurema(planoAnualId, objetivoJuremaId);
 
+                        repositorioObjetivosAula.Salvar(new ObjetivoAprendizagemAula(planoAula.Id, objetivoPlanoAnualId));
                     }
 
                 unitOfWork.PersistirTransacao();

--- a/src/SME.SGP.Aplicacao/Consultas/ConsultasObjetivoAprendizagem.cs
+++ b/src/SME.SGP.Aplicacao/Consultas/ConsultasObjetivoAprendizagem.cs
@@ -87,6 +87,11 @@ namespace SME.SGP.Aplicacao
             return repositorioObjetivosPlano.ObterDisciplinasDoBimestrePlanoAula(ano, bimestre, turmaId, componenteCurricularId);
         }
 
+        public async Task<long> ObterIdPorObjetivoAprendizagemJurema(long planoId, long objetivoAprendizagemJuremaId)
+        {
+            return repositorioObjetivosPlano.ObterIdPorObjetivoAprendizagemJurema(planoId, objetivoAprendizagemJuremaId);
+        }
+
         public async Task<IEnumerable<ObjetivoAprendizagemDto>> ObterObjetivosPlanoDisciplina(int ano, int bimestre, long turmaId, long componenteCurricularId, long disciplinaId)
         {
             var objetivosPlano = repositorioObjetivosPlano.ObterObjetivosPlanoDisciplina(ano, bimestre, turmaId, componenteCurricularId, disciplinaId);

--- a/src/SME.SGP.Aplicacao/Consultas/ConsultasPlanoAnual.cs
+++ b/src/SME.SGP.Aplicacao/Consultas/ConsultasPlanoAnual.cs
@@ -51,6 +51,12 @@ namespace SME.SGP.Aplicacao
             return retorno;
         }
 
+        public async Task<long> ObterIdPlanoAnualPorAnoEscolaBimestreETurma(int ano, string escolaId, long turmaId, int bimestre, long disciplinaId)
+        {
+            var plano = repositorioPlanoAnual.ObterPlanoAnualSimplificadoPorAnoEscolaBimestreETurma(ano, escolaId, turmaId, bimestre, disciplinaId);
+            return plano.Id;
+        }
+
         public async Task<PlanoAnualObjetivosDisciplinaDto> ObterObjetivosEscolaTurmaDisciplina(FiltroPlanoAnualDisciplinaDto filtro)
         {
             var planoAnual = repositorioPlanoAnual.ObterPlanoObjetivosEscolaTurmaDisciplina(filtro.AnoLetivo, 

--- a/src/SME.SGP.Aplicacao/Consultas/ConsultasPlanoAula.cs
+++ b/src/SME.SGP.Aplicacao/Consultas/ConsultasPlanoAula.cs
@@ -52,7 +52,7 @@ namespace SME.SGP.Aplicacao.Consultas
                 var objetivosAula = await consultasObjetivosAula.ObterObjetivosPlanoAula(plano.Id);
                 // Filtra objetivos anual com os objetivos da aula
                 planoAulaDto.ObjetivosAprendizagemAula = planoAnual.ObjetivosAprendizagem
-                                    .Where(c => objetivosAula.Any(a => a.ObjetivoAprendizagemPlanoId == c.Id))
+                                    .Where(c => objetivosAula.Any(a => a.ObjetivoAprendizagemPlano.ObjetivoAprendizagemJuremaId == c.Id))
                                     .ToList();
             }
 

--- a/src/SME.SGP.Aplicacao/Interfaces/Consultas/IConsultasObjetivoAprendizagem.cs
+++ b/src/SME.SGP.Aplicacao/Interfaces/Consultas/IConsultasObjetivoAprendizagem.cs
@@ -15,5 +15,7 @@ namespace SME.SGP.Aplicacao
         Task<IEnumerable<ComponenteCurricularSimplificadoDto>> ObterDisciplinasDoBimestrePlanoAnual(int ano, int bimestre, long turmaId, long componenteCurricularId);
 
         Task<IEnumerable<ObjetivoAprendizagemDto>> ObterObjetivosPlanoDisciplina(int ano, int bimestre, long turmaId, long componenteCurricularId, long disciplinaId);
+
+        Task<long> ObterIdPorObjetivoAprendizagemJurema(long planoId, long objetivoAprendizagemJuremaId);
     }
 }

--- a/src/SME.SGP.Aplicacao/Interfaces/Consultas/IConsultasPlanoAnual.cs
+++ b/src/SME.SGP.Aplicacao/Interfaces/Consultas/IConsultasPlanoAnual.cs
@@ -11,6 +11,7 @@ namespace SME.SGP.Aplicacao
 
         Task<PlanoAnualObjetivosDisciplinaDto> ObterObjetivosEscolaTurmaDisciplina(FiltroPlanoAnualDisciplinaDto filtroPlanoDisciplinaDto);
 
+        Task<long> ObterIdPlanoAnualPorAnoEscolaBimestreETurma(int ano, string escolaId, long turmaId, int bimestre, long disciplinaId);
         bool ValidarPlanoAnualExistente(FiltroPlanoAnualDto filtroPlanoAnualDto);
     }
 }

--- a/src/SME.SGP.Dados/Repositorios/RepositorioObjetivoAprendizagemAula.cs
+++ b/src/SME.SGP.Dados/Repositorios/RepositorioObjetivoAprendizagemAula.cs
@@ -23,9 +23,20 @@ namespace SME.SGP.Dados.Repositorios
 
         public async Task<IEnumerable<ObjetivoAprendizagemAula>> ObterObjetivosPlanoAula(long planoAulaId)
         {
-            var query = "select * from objetivo_aprendizagem_aula where plano_aula_id = @planoAulaId";
+            var query = @"select a.id, a.plano_aula_id, a.objetivo_aprendizagem_plano_id, 
+                            p.id as objetivoPlanoId, p.objetivo_aprendizagem_jurema_id, p.componente_curricular_id
+                          from objetivo_aprendizagem_aula a
+                         inner join objetivo_aprendizagem_plano p on p.id = a.objetivo_aprendizagem_plano_id
+                         where a.plano_aula_id = @planoAulaId";
 
-            return await database.Conexao.QueryAsync<ObjetivoAprendizagemAula>(query, new { planoAulaId });
+            return await database.Conexao.QueryAsync<ObjetivoAprendizagemAula, ObjetivoAprendizagemPlano, ObjetivoAprendizagemAula>(query, 
+                (objetivoAula, objetivoPlano) =>
+                {
+                    objetivoAula.ObjetivoAprendizagemPlano = objetivoPlano;
+                    return objetivoAula;
+                },
+                new { planoAulaId },
+                splitOn: "id, objetivoPlanoId");
         }
     }
 }

--- a/src/SME.SGP.Dados/Repositorios/RepositorioObjetivoAprendizagemPlano.cs
+++ b/src/SME.SGP.Dados/Repositorios/RepositorioObjetivoAprendizagemPlano.cs
@@ -34,6 +34,13 @@ namespace SME.SGP.Dados.Repositorios
 
         }
 
+        public long ObterIdPorObjetivoAprendizagemJurema(long planoId, long objetivoAprendizagemJuremaId)
+        {
+            var query = "select id from objetivo_aprendizagem_plano where plano_id = @planoId and objetivo_aprendizagem_jurema_id = @objetivoAprendizagemJuremaId";
+
+            return database.Conexao.QueryFirst<long>(query, new { planoId, objetivoAprendizagemJuremaId });
+        }
+
         public IEnumerable<ObjetivoAprendizagemPlano> ObterObjetivosAprendizagemPorIdPlano(long idPlano)
         {
             return database.Conexao.Query<ObjetivoAprendizagemPlano>("select * from objetivo_aprendizagem_plano where plano_id = @Id", new { Id = idPlano });

--- a/src/SME.SGP.Dominio.Interfaces/Repositorios/IRepositorioObjetivoAprendizagemPlano.cs
+++ b/src/SME.SGP.Dominio.Interfaces/Repositorios/IRepositorioObjetivoAprendizagemPlano.cs
@@ -9,5 +9,7 @@ namespace SME.SGP.Dominio.Interfaces
         IEnumerable<ObjetivoAprendizagemPlano> ObterObjetivosPlanoDisciplina(int ano, int bimestre, long turmaId, long componenteCurricularId, long disciplinaId);
 
         IEnumerable<ComponenteCurricularSimplificadoDto> ObterDisciplinasDoBimestrePlanoAula(int ano, int bimestre, long turmaId, long componenteCurricularId);
+
+        long ObterIdPorObjetivoAprendizagemJurema(long planoId, long objetivoAprendizagemJuremaId);
     }
 }

--- a/src/SME.SGP.Infra/Dtos/PlanoAulaDto.cs
+++ b/src/SME.SGP.Infra/Dtos/PlanoAulaDto.cs
@@ -15,7 +15,6 @@ namespace SME.SGP.Infra
 
         [Required(ErrorMessage = "É necessário vincular o plano a uma aula.")]
         public long AulaId { get; set; }
-
-        public List<long> ObjetivosAprendizagemAula { get; set; }
+        public List<long> ObjetivosAprendizagemJurema { get; set; }
     }
 }

--- a/teste/SME.SGP.Aplicacao.Teste/Comandos/ComandosPlanoAulaTeste.cs
+++ b/teste/SME.SGP.Aplicacao.Teste/Comandos/ComandosPlanoAulaTeste.cs
@@ -107,7 +107,7 @@ namespace SME.SGP.Aplicacao.Teste.Comandos
         public async void Deve_Incluir_Plano_Aula_Com_Objetivos()
         {
             // ARRANGE
-            planoAulaDto.ObjetivosAprendizagemAula = new List<long>() { 5 };
+            planoAulaDto.ObjetivosAprendizagemJurema = new List<long>() { 5 };
 
             // ACT
             await comandosPlanoAula.Salvar(planoAulaDto);


### PR DESCRIPTION
Ao filtrar objetivos do plano aula não estava funcionando pois o Id do objetivo se trata do Id do Jurema e não do Id do objetivo no plano anual;

Realizado alterações para que o filtro ocorra pelo Id do Jurema no objetivo do plano anual;
Alterado também o post do plano aula para que seja enviado a lista de Ids de objetivo do Jurema;

[AB#4507](https://dev.azure.com/amcomgov/Novo%20SGP/_workitems/edit/4507)