### PR TITLE
8851 - Corrigido geração da recorrencia de aulas

### DIFF
--- a/src/SME.SGP.Dominio/Entidades/Aula.cs
+++ b/src/SME.SGP.Dominio/Entidades/Aula.cs
@@ -37,7 +37,6 @@ namespace SME.SGP.Dominio
                 CriadoPor = CriadoPor,
                 CriadoRF = CriadoRF,
                 Excluido = Excluido,
-                Id = Id,
                 UeId = UeId,
                 AulaPai = AulaPai,
                 DisciplinaId = DisciplinaId,

--- a/src/SME.SGP.Dominio/Entidades/Evento.cs
+++ b/src/SME.SGP.Dominio/Entidades/Evento.cs
@@ -73,7 +73,6 @@ namespace SME.SGP.Dominio
                 Excluido = Excluido,
                 FeriadoCalendario = FeriadoCalendario,
                 FeriadoId = FeriadoId,
-                Id = Id,
                 Letivo = Letivo,
                 Nome = Nome,
                 TipoCalendario = TipoCalendario,


### PR DESCRIPTION
No clone estava carregando o Id e fazia com que o Salvar atualizasse a mesma entidade;
Alterado também a logica para buscar o inicio e fim do periodo de recorrencia pois estava gerando a partir do proximo periodo cadatrado ao inves de gerar a partir da data da aula.
Ex: Aula cadastrada dia 15/02 com recorrencia em todos os bimestres.
Estava gerando aulas recorrentes a partir do dia 01/04 (que seria o proximo periodo cadastrado);

[AB#8851](https://dev.azure.com/amcomgov/Novo%20SGP/_workitems/edit/8851)