### PR TITLE
Inclusão da auditoria no obter por ID

### DIFF
--- a/src/SME.SGP.Api/Controllers/AtribuicaoEsporadicaController.cs
+++ b/src/SME.SGP.Api/Controllers/AtribuicaoEsporadicaController.cs
@@ -32,24 +32,26 @@ namespace SME.SGP.Api.Controllers
         }
 
         [HttpGet("{id}")]
-        [ProducesResponseType(typeof(AtribuicaoEsporadicaDto), 200)]
+        [ProducesResponseType(typeof(AtribuicaoEsporadicaCompletaDto), 200)]
         [ProducesResponseType(typeof(RetornoBaseDto), 500)]
         [Permissao(Permissao.AE_C, Policy = "Bearer")]
         public IActionResult Obter(long id, [FromServices]IConsultasAtribuicaoEsporadica consultasAtribuicaoEsporadica)
         {
             var atribuicaoEsporadica = consultasAtribuicaoEsporadica.ObterPorId(id);
+
             if (atribuicaoEsporadica is null)
-                return StatusCode(204);
-            else return Ok(atribuicaoEsporadica);
+                return NoContent();
+
+            return Ok(atribuicaoEsporadica);
         }
 
         [HttpPost]
         [ProducesResponseType(200)]
         [ProducesResponseType(typeof(RetornoBaseDto), 500)]
         [Permissao(Permissao.AE_A, Permissao.AE_I, Policy = "Bearer")]
-        public IActionResult Post([FromBody]AtribuicaoEsporadicaCompletaDto atribuicaoEsporadicaCompletaDto, [FromServices]IComandosAtribuicaoEsporadica comandosAtribuicaoEsporadica)
+        public IActionResult Post([FromBody]AtribuicaoEsporadicaDto atribuicaoEsporadicaDto, [FromServices]IComandosAtribuicaoEsporadica comandosAtribuicaoEsporadica)
         {
-            comandosAtribuicaoEsporadica.Salvar(atribuicaoEsporadicaCompletaDto);
+            comandosAtribuicaoEsporadica.Salvar(atribuicaoEsporadicaDto);
 
             return Ok();
         }

--- a/src/SME.SGP.Aplicacao/Comandos/ComandosAtribuicaoEsporadica.cs
+++ b/src/SME.SGP.Aplicacao/Comandos/ComandosAtribuicaoEsporadica.cs
@@ -27,14 +27,14 @@ namespace SME.SGP.Aplicacao
             await repositorioAtribuicaoEsporadica.SalvarAsync(atribuicaoEsporadica);
         }
 
-        public void Salvar(AtribuicaoEsporadicaCompletaDto atruibuicaoEsporadicaCompletaDto)
+        public void Salvar(AtribuicaoEsporadicaDto atruibuicaoEsporadicaDto)
         {
-            var entidade = ObterEntidade(atruibuicaoEsporadicaCompletaDto);
+            var entidade = ObterEntidade(atruibuicaoEsporadicaDto);
 
-            servicoAtribuicaoEsporadica.Salvar(entidade, atruibuicaoEsporadicaCompletaDto.AnoLetivo);
+            servicoAtribuicaoEsporadica.Salvar(entidade, atruibuicaoEsporadicaDto.AnoLetivo);
         }
 
-        private AtribuicaoEsporadica DtoParaEntidade(AtribuicaoEsporadicaCompletaDto Dto)
+        private AtribuicaoEsporadica DtoParaEntidade(AtribuicaoEsporadicaDto Dto)
         {
             return new AtribuicaoEsporadica
             {
@@ -47,7 +47,7 @@ namespace SME.SGP.Aplicacao
             };
         }
 
-        private AtribuicaoEsporadica ObterEntidade(AtribuicaoEsporadicaCompletaDto atribuicaoEsporadicaDto)
+        private AtribuicaoEsporadica ObterEntidade(AtribuicaoEsporadicaDto atribuicaoEsporadicaDto)
         {
             if (atribuicaoEsporadicaDto.Id == 0)
                 return DtoParaEntidade(atribuicaoEsporadicaDto);

--- a/src/SME.SGP.Aplicacao/Consultas/ConsultasAtribuicaoEsporadica.cs
+++ b/src/SME.SGP.Aplicacao/Consultas/ConsultasAtribuicaoEsporadica.cs
@@ -42,14 +42,39 @@ namespace SME.SGP.Aplicacao.Consultas
             return retorno;
         }
 
-        public AtribuicaoEsporadicaDto ObterPorId(long id)
+        public AtribuicaoEsporadicaCompletaDto ObterPorId(long id)
         {
             var atribuicaoEsporadica = repositorioAtribuicaoEsporadica.ObterPorId(id);
 
             if (atribuicaoEsporadica is null)
                 return null;
 
-            return EntidadeParaDto(atribuicaoEsporadica);
+            return EntidadeParaDtoCompleto(atribuicaoEsporadica);
+        }
+
+        private AtribuicaoEsporadicaCompletaDto EntidadeParaDtoCompleto(AtribuicaoEsporadica entidade)
+        {
+            var professorResumo = servicoEOL.ObterResumoProfessorPorRFAnoLetivo(entidade.ProfessorRf, entidade.DataInicio.Year).Result;
+
+            return new AtribuicaoEsporadicaCompletaDto
+            {
+                AnoLetivo = entidade.DataInicio.Year,
+                DataFim = entidade.DataFim,
+                DataInicio = entidade.DataInicio,
+                DreId = entidade.DreId,
+                Excluido = entidade.Excluido,
+                Id = entidade.Id,
+                Migrado = entidade.Migrado,
+                ProfessorNome = professorResumo != null ? professorResumo.Nome : "Professor não encontrado",
+                ProfessorRf = entidade.ProfessorRf,
+                UeId = entidade.UeId,
+                AlteradoEm = entidade.AlteradoEm,
+                AlteradoPor = entidade.AlteradoPor,
+                AlteradoRF = entidade.AlteradoRF,
+                CriadoEm = entidade.CriadoEm,
+                CriadoPor = entidade.CriadoPor,
+                CriadoRF = entidade.CriadoRF
+            };
         }
 
         private AtribuicaoEsporadicaDto EntidadeParaDto(AtribuicaoEsporadica entidade)

--- a/src/SME.SGP.Aplicacao/Interfaces/Comandos/IComandosAtribuicaoEsporadica.cs
+++ b/src/SME.SGP.Aplicacao/Interfaces/Comandos/IComandosAtribuicaoEsporadica.cs
@@ -7,6 +7,6 @@ namespace SME.SGP.Aplicacao
     {
         Task Excluir(long idAtribuicaoEsporadica);
 
-        void Salvar(AtribuicaoEsporadicaCompletaDto atruibuicaoEsporadicaCompletaDto);
+        void Salvar(AtribuicaoEsporadicaDto atruibuicaoEsporadicaDto);
     }
 }

--- a/src/SME.SGP.Aplicacao/Interfaces/Consultas/IConsultasAtribuicaoEsporadica.cs
+++ b/src/SME.SGP.Aplicacao/Interfaces/Consultas/IConsultasAtribuicaoEsporadica.cs
@@ -7,6 +7,6 @@ namespace SME.SGP.Aplicacao.Interfaces
     {
         Task<PaginacaoResultadoDto<AtribuicaoEsporadicaDto>> Listar(FiltroAtribuicaoEsporadicaDto filtro);
 
-        AtribuicaoEsporadicaDto ObterPorId(long id);
+        AtribuicaoEsporadicaCompletaDto ObterPorId(long id);
     }
 }


### PR DESCRIPTION
Inclusão das informações de auditoria no obter por ID.

Utilizando DTO simplificado no POST, removendo campos desnecessarios.

[AB#8899](https://dev.azure.com/amcomgov/c1dcf343-60ee-40b6-a30a-3b9c12c6d220/_workitems/edit/8899)