### PR TITLE
9309 - Alteração de Aula consistindo grade

### DIFF
--- a/src/SME.SGP.Dados/Repositorios/RepositorioAula.cs
+++ b/src/SME.SGP.Dados/Repositorios/RepositorioAula.cs
@@ -33,12 +33,12 @@ namespace SME.SGP.Dados.Repositorios
             });
         }
 
-        public async Task<IEnumerable<AulaDto>> ObterAulas(long tipoCalendarioId, string turmaId, string ueId, string codigoRf, int? mes = null, int? semanaAno = null)
+        public async Task<IEnumerable<AulaDto>> ObterAulas(long tipoCalendarioId, string turmaId, string ueId, string codigoRf, int? mes = null, int? semanaAno = null, string disciplinaId = null)
         {
             StringBuilder query = new StringBuilder();
             MontaCabecalho(query);
             query.AppendLine("FROM public.aula a");
-            MontaWhere(query, tipoCalendarioId, turmaId, ueId, mes, null, codigoRf, null, semanaAno);
+            MontaWhere(query, tipoCalendarioId, turmaId, ueId, mes, null, codigoRf, disciplinaId, semanaAno);
             return (await database.Conexao.QueryAsync<AulaDto>(query.ToString(), new { tipoCalendarioId, turmaId, ueId, codigoRf, mes, semanaAno }));
         }
 

--- a/src/SME.SGP.Dominio.Interfaces/Repositorios/IRepositorioAula.cs
+++ b/src/SME.SGP.Dominio.Interfaces/Repositorios/IRepositorioAula.cs
@@ -9,7 +9,7 @@ namespace SME.SGP.Dominio.Interfaces
     {
         Task<AulaConsultaDto> ObterAulaDataTurmaDisciplina(DateTime data, string turmaId, string disciplinaId);
 
-        Task<IEnumerable<AulaDto>> ObterAulas(long tipoCalendarioId, string turmaId, string ueId, string CodigoRf, int? mes = null, int? semanaAno = null);
+        Task<IEnumerable<AulaDto>> ObterAulas(long tipoCalendarioId, string turmaId, string ueId, string CodigoRf, int? mes = null, int? semanaAno = null, string disciplinaId = null);
 
         Task<IEnumerable<AulaDto>> ObterAulas(long tipoCalendarioId, string turmaId, string ueId, string CodigoRf);
 

--- a/src/SME.SGP.Dominio.Servicos/ServicoAula.cs
+++ b/src/SME.SGP.Dominio.Servicos/ServicoAula.cs
@@ -176,7 +176,7 @@ namespace SME.SGP.Dominio.Servicos
                 if (!ehInclusao)
                 {
                     // Na alteração tem que considerar que uma aula possa estar mudando de dia na mesma semana, então não soma as aulas do proprio registro
-                    var aulasSemana = await repositorioAula.ObterAulas(aula.TipoCalendarioId, aula.TurmaId, aula.UeId, null, semana);
+                    var aulasSemana = await repositorioAula.ObterAulas(aula.TipoCalendarioId, aula.TurmaId, aula.UeId, usuario.CodigoRf, null, semana, aula.DisciplinaId);
                     var quantidadeAulasSemana = aulasSemana.Where(a => a.Id != aula.Id).Sum(a => a.Quantidade);
 
                     quantidadeAulasRestantes = gradeAulas.QuantidadeAulasGrade - quantidadeAulasSemana;


### PR DESCRIPTION
A alteração de aula estava chamando o metodo incorreto para contagem de aulas na semana ultrapassando o limite de aulas cadastrados na grade, considerando aulas de todas as disciplinas da turma;

Incluso parametro de disciplina no metodo chamado e alterado a chamada na validação da alteração da aula;

[AB#9303](https://dev.azure.com/amcomgov/Novo%20SGP/_workitems/edit/9303)