### PR TITLE
Revisão de diversos controles do WorkerService

### DIFF
--- a/src/Bibliotecas/SME.Background.Hangfire/Startup.cs
+++ b/src/Bibliotecas/SME.Background.Hangfire/Startup.cs
@@ -1,40 +1,47 @@
-﻿using Microsoft.AspNetCore.Builder;
+﻿using Hangfire;
+using Hangfire.Dashboard;
+using Hangfire.PostgreSql;
+using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using System;
 
 namespace SME.Background.Hangfire
 {
     public class Startup
     {
-        private IConfiguration configuration;
+        private readonly IConfiguration configuration;
+        private readonly string connectionString;
 
         public Startup(IConfiguration configuration)
         {
             this.configuration = configuration;
+            var paramConnectionString = this.configuration.GetConnectionString("SGP-Postgres");
+            this.connectionString = (!paramConnectionString.EndsWith(';') ? paramConnectionString + ";" : paramConnectionString) + "Application Name=SGP Worker Service Dashboard";
         }
 
         public void Configure(IApplicationBuilder app, IHostingEnvironment env)
         {
-            //app.UseHangfireDashboard("/worker", new DashboardOptions()
-            //{
-            //    IsReadOnlyFunc = (DashboardContext context) => !env.IsDevelopment(),
-            //    Authorization = new[] { new DashboardAuthorizationFilter() }
-            //});
+            app.UseHangfireDashboard("/worker", new DashboardOptions()
+            {
+                IsReadOnlyFunc = (DashboardContext context) => !env.IsDevelopment(),
+                Authorization = new[] { new DashboardAuthorizationFilter() },
+                StatsPollingInterval = 10000 // atualiza a cada 10s
+            });
         }
 
         public void ConfigureServices(IServiceCollection services)
         {
-            //services.AddHangfire(configuration => configuration
-            //    .SetDataCompatibilityLevel(CompatibilityLevel.Version_170)
-            //    .UseSimpleAssemblyNameTypeSerializer()
-            //    .UseRecommendedSerializerSettings()
-            //    .UseFilter<AutomaticRetryAttribute>(new AutomaticRetryAttribute() { Attempts = 0 })
-            //    .UsePostgreSqlStorage(this.configuration.GetConnectionString("SGP-Postgres"), new PostgreSqlStorageOptions()
-            //    {
-            //        QueuePollInterval = TimeSpan.FromSeconds(10),
-            //        SchemaName = "hangfire"
-            //    }));
+            services.AddHangfire(configuration => configuration
+                .SetDataCompatibilityLevel(CompatibilityLevel.Version_170)
+                .UseSimpleAssemblyNameTypeSerializer()
+                .UseRecommendedSerializerSettings()
+                .UseFilter<AutomaticRetryAttribute>(new AutomaticRetryAttribute() { Attempts = 0 })
+                .UsePostgreSqlStorage(connectionString, new PostgreSqlStorageOptions()
+                {
+                    SchemaName = "hangfire"
+                }));
         }
     }
 }

--- a/src/Bibliotecas/SME.SGP.Background/ContextFilterAttribute.cs
+++ b/src/Bibliotecas/SME.SGP.Background/ContextFilterAttribute.cs
@@ -38,7 +38,7 @@ namespace SME.SGP.Hangfire
         public void OnPerforming(PerformingContext filterContext)
         {
             var contextoTransiente = filterContext.GetJobParameter<WorkerContext>("contextoAplicacao");
-            WorkerServiceScope.TransientContexts.TryAdd(Thread.CurrentThread.Name, contextoTransiente);
+            WorkerServiceScope.TransientContexts.TryAdd(WorkerContext.ContextIdentifier, contextoTransiente);
 
         }
 

--- a/src/SME.SGP.Api/Startup.cs
+++ b/src/SME.SGP.Api/Startup.cs
@@ -5,6 +5,8 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Prometheus;
 using SME.Background.Core;
+using SME.Background.Hangfire;
+using SME.SGP.Background;
 using SME.SGP.Dados.Mapeamentos;
 using SME.SGP.IoC;
 using Swashbuckle.AspNetCore.Swagger;
@@ -92,13 +94,13 @@ namespace SME.SGP.Api
 
             Orquestrador.Inicializar(services.BuildServiceProvider());
 
-            //if (Configuration.GetValue<bool>("FF_BackgroundEnabled", false))
-            //{
-            //    Orquestrador.Registrar(new Processor(Configuration, "SGP-Postgres"));
-            //    RegistraServicosRecorrentes.Registrar();
-            //}
-            //else
-            Orquestrador.Desativar();
+            if (Configuration.GetValue<bool>("FF_BackgroundEnabled", false))
+            {
+                Orquestrador.Registrar(new Processor(Configuration, "SGP-Postgres"));
+                RegistraServicosRecorrentes.Registrar();
+            }
+            else
+                Orquestrador.Desativar();
         }
     }
 }

--- a/src/SME.SGP.Dominio.Servicos.Teste/ServicoAulaTeste.cs
+++ b/src/SME.SGP.Dominio.Servicos.Teste/ServicoAulaTeste.cs
@@ -86,7 +86,7 @@ namespace SME.SGP.Dominio.Servicos.Teste
             aula.Id = 1;
             aula.DataAula = aula.DataAula.AddDays(2);
 
-            var msg = await servicoAula.Salvar(aula, usuario, RecorrenciaAula.RepetirBimestreAtual);
+            var msg = servicoAula.Salvar(aula, usuario, RecorrenciaAula.RepetirBimestreAtual);
 
             // ASSERT
             Assert.False(msg == "");
@@ -99,7 +99,7 @@ namespace SME.SGP.Dominio.Servicos.Teste
         {
             servicoDiaLetivo.Setup(a => a.ValidarSeEhDiaLetivo(It.IsAny<DateTime>(), It.IsAny<long>(), It.IsAny<string>(), It.IsAny<string>())).Returns(false);
 
-            await Assert.ThrowsAsync<NegocioException>(() => servicoAula.Salvar(aula, usuario, aula.RecorrenciaAula));
+            Assert.Throws<NegocioException>(() => servicoAula.Salvar(aula, usuario, aula.RecorrenciaAula));
         }
 
         [Fact]
@@ -107,7 +107,7 @@ namespace SME.SGP.Dominio.Servicos.Teste
         {
             aula.DisciplinaId = "2";
 
-            await Assert.ThrowsAsync<NegocioException>(() => servicoAula.Salvar(aula, usuario, aula.RecorrenciaAula));
+            Assert.Throws<NegocioException>(() => servicoAula.Salvar(aula, usuario, aula.RecorrenciaAula));
         }
 
         [Fact]
@@ -115,7 +115,7 @@ namespace SME.SGP.Dominio.Servicos.Teste
         {
             aula.Quantidade = 2;
 
-            await Assert.ThrowsAsync<NegocioException>(() => servicoAula.Salvar(aula, usuario, aula.RecorrenciaAula));
+            Assert.Throws<NegocioException>(() => servicoAula.Salvar(aula, usuario, aula.RecorrenciaAula));
         }
 
         [Fact]
@@ -124,7 +124,7 @@ namespace SME.SGP.Dominio.Servicos.Teste
             aula.TipoAula = TipoAula.Reposicao;
             aula.RecorrenciaAula = RecorrenciaAula.RepetirBimestreAtual;
 
-            await Assert.ThrowsAsync<NegocioException>(() => servicoAula.Salvar(aula, usuario, aula.RecorrenciaAula));
+            Assert.Throws<NegocioException>(() => servicoAula.Salvar(aula, usuario, aula.RecorrenciaAula));
         }
 
         [Fact]
@@ -144,7 +144,7 @@ namespace SME.SGP.Dominio.Servicos.Teste
         public async void Deve_Incluir_Aula()
         {
             //ACT
-            await servicoAula.Salvar(aula, usuario, RecorrenciaAula.AulaUnica);
+            servicoAula.Salvar(aula, usuario, RecorrenciaAula.AulaUnica);
 
             //ASSERT
             repositorioAula.Verify(c => c.Salvar(aula), Times.Once);
@@ -167,7 +167,7 @@ namespace SME.SGP.Dominio.Servicos.Teste
             consultasPeriodoEscolar.Setup(a => a.ObterFimPeriodoRecorrencia(It.IsAny<long>(), It.IsAny<DateTime>(), It.IsAny<RecorrenciaAula>())).Returns(new DateTime(2019, 3, 31));
 
             //ACT
-            await servicoAula.Salvar(aula, usuario, aula.RecorrenciaAula);
+            servicoAula.Salvar(aula, usuario, aula.RecorrenciaAula);
 
             //ASSERT
             repositorioAula.Verify(c => c.Salvar(aula), Times.Exactly(1));

--- a/src/SME.SGP.Infra/Contexto/WorkerContext.cs
+++ b/src/SME.SGP.Infra/Contexto/WorkerContext.cs
@@ -18,9 +18,9 @@ namespace SME.SGP.Infra.Contexto
 
             WorkerContext contextoTransiente;
 
-            if (!string.IsNullOrWhiteSpace(Thread.CurrentThread.Name))
+            if (!string.IsNullOrWhiteSpace(WorkerContext.ContextIdentifier))
             {
-                if (WorkerServiceScope.TransientContexts.TryGetValue(Thread.CurrentThread.Name, out contextoTransiente))
+                if (WorkerServiceScope.TransientContexts.TryGetValue(WorkerContext.ContextIdentifier, out contextoTransiente))
                     AtribuirContexto(contextoTransiente);
             }
         }
@@ -34,6 +34,14 @@ namespace SME.SGP.Infra.Contexto
         public void Dispose()
         {
             Variaveis.Clear();
+        }
+
+        public static string ContextIdentifier
+        {
+            get
+            {
+                return Thread.CurrentThread.ManagedThreadId.ToString();
+            }
         }
     }
 

--- a/src/SME.SGP.Infra/Escopo/WorkerServiceScope.cs
+++ b/src/SME.SGP.Infra/Escopo/WorkerServiceScope.cs
@@ -22,18 +22,18 @@ namespace SME.SGP.Infra.Escopo
         public static IDisposable AddTransientDisposableServices(IDisposable service)
         {
             if (service != null)
-                if (TransientServices.ContainsKey(Thread.CurrentThread.Name))
+                if (TransientServices.ContainsKey(WorkerContext.ContextIdentifier))
                 {
                     List<IDisposable> services = null;
 
-                    if (TransientServices.TryGetValue(Thread.CurrentThread.Name, out services))
+                    if (TransientServices.TryGetValue(WorkerContext.ContextIdentifier, out services))
                     {
                         services.Add(service);
-                        TransientServices[Thread.CurrentThread.Name] = services;
+                        TransientServices[WorkerContext.ContextIdentifier] = services;
                     }
                 }
                 else
-                    TransientServices.TryAdd(Thread.CurrentThread.Name, new List<IDisposable>(new[] { service }));
+                    TransientServices.TryAdd(WorkerContext.ContextIdentifier, new List<IDisposable>(new[] { service }));
 
             return service;
         }
@@ -43,14 +43,14 @@ namespace SME.SGP.Infra.Escopo
             List<IDisposable> services = null;
             WorkerContext context = null;
 
-            if (TransientServices.TryRemove(Thread.CurrentThread.Name, out services))
+            if (TransientServices.TryRemove(WorkerContext.ContextIdentifier, out services))
             {
                 foreach (var item in services)
                     if (item != null)
                         item.Dispose();
 
             }
-            if (TransientContexts.TryRemove(Thread.CurrentThread.Name, out context))
+            if (TransientContexts.TryRemove(WorkerContext.ContextIdentifier, out context))
                 context.Dispose();
         }
     }

--- a/src/SME.SGP.WorkerService/WorkerService.cs
+++ b/src/SME.SGP.WorkerService/WorkerService.cs
@@ -58,7 +58,7 @@ namespace SME.SGP.Worker.Service
 
         internal static void Configurar(IConfiguration config, IServiceCollection services)
         {
-            HangfireWorkerService = new SME.Background.Core.Servidor<SME.Background.Hangfire.Worker>(new SME.Background.Hangfire.Worker(config, services, "SGP-Postgres"));
+            HangfireWorkerService = new SME.Background.Core.Servidor<SME.Background.Hangfire.Worker>(new SME.Background.Hangfire.Worker(config, services, config.GetConnectionString("SGP-Postgres")));
         }
 
         internal static void ConfigurarDependencias(IConfiguration configuration, IServiceCollection services)


### PR DESCRIPTION
Revisão de diversos controles do WorkerService para mitigar problema de queda dos serviços

Foram incluídos as variáveis de ambiente:
- BackgroundWorkerParallelDegree (determina quantos jobs serão executados ao mesmo tempo)
- BackgroundWorkerQueuePollInterval (de quanto em quanto tempo o Hangfire busca novos jobs)

Outras alterações:
- Aumento para 10s o tempo do Dashboard buscar novidades
- Inclusão do Application Name do Worker Server e do Worker Server - Dashboard para acompanhamento das conexões no PostgreSQL
- Melhorias na identificação da Thread por parte da contexto do serviço

[AB#9531](https://dev.azure.com/amcomgov/c1dcf343-60ee-40b6-a30a-3b9c12c6d220/_workitems/edit/9531)
[AB#9369](https://dev.azure.com/amcomgov/c1dcf343-60ee-40b6-a30a-3b9c12c6d220/_workitems/edit/9369)