### PR TITLE
9400 - Tratamento de erro ao consultar cache, assumir que token é valido

### DIFF
--- a/src/SME.SGP.Api/Middlewares/TokenServiceMiddleware.cs
+++ b/src/SME.SGP.Api/Middlewares/TokenServiceMiddleware.cs
@@ -27,6 +27,7 @@ namespace SME.SGP.Api.Middlewares
                 return;
             }
 
+            context.Response.Headers.Add("Token-Expired", new[] { "true" });
             context.Response.StatusCode = (int)HttpStatusCode.Unauthorized;
         }
     }

--- a/src/SME.SGP.Aplicacao/Servicos/ServicoTokenJwt.cs
+++ b/src/SME.SGP.Aplicacao/Servicos/ServicoTokenJwt.cs
@@ -101,7 +101,11 @@ namespace SME.SGP.Aplicacao.Servicos
 
         #region Private Methods
         private bool TokenAtivo(string token)
-            => cache.Obter(ObterChaveToken(token)) == token;
+        {
+            var tokenCache = cache.Obter(ObterChaveToken(token));
+            
+            return tokenCache == null || tokenCache == token;
+        }
 
         private void SalvarToken(string usuarioLogin, string tokenStr)
             => cache.SalvarAsync(ObterChaveLogin(usuarioLogin), tokenStr).Wait();


### PR DESCRIPTION
No caso de não conseguir buscar o token do cache, a comparação do token atual com o ativo estava retornando falso, fazendo com que o request retornasse 401 fazendo o redirect do front para o login;

[AB#6686](https://dev.azure.com/amcomgov/Novo%20SGP/_workitems/edit/6686)
