### PR TITLE
9883 - Tratamento no filtro para evitar erro de referencia

### DIFF
--- a/src/SME.SGP.Aplicacao/Consultas/ConsultasSupervisor.cs
+++ b/src/SME.SGP.Aplicacao/Consultas/ConsultasSupervisor.cs
@@ -171,7 +171,7 @@ namespace SME.SGP.Aplicacao
                 foreach (var supervisorEscolaDre in supervisoresEscolasDres.GroupBy(a => a.SupervisorId).Select(a => a.Key).ToList())
                 {
                     var supervisorEscolasDto = new SupervisorEscolasDto();
-                    supervisorEscolasDto.SupervisorNome = supervisores.FirstOrDefault(a => a.CodigoRF == supervisorEscolaDre).NomeServidor;
+                    supervisorEscolasDto.SupervisorNome = supervisores.FirstOrDefault(a => a.CodigoRF == supervisorEscolaDre)?.NomeServidor;
                     supervisorEscolasDto.SupervisorId = supervisorEscolaDre;
 
                     var idsEscolasDoSupervisor = supervisoresEscolasDres.Where(a => a.SupervisorId == supervisorEscolaDre)


### PR DESCRIPTION
Quando por algum motivo desconhecido o filtro de CodigoRF do registro que vem do EOL não bate com o supervisor_id, ocorria erro de referencia.

Como esse filtro é feito apenas para buscar o nome do supervisor, foi tratado para deixar o nome vazio e não dar erro de referencia.

[AB#9637](https://dev.azure.com/amcomgov/Novo%20SGP/_workitems/edit/9637)