### PR TITLE
9400 - Incluso log no sentry quando não Redis offline

### DIFF
--- a/src/SME.SGP.Api/Middlewares/TokenServiceMiddleware.cs
+++ b/src/SME.SGP.Api/Middlewares/TokenServiceMiddleware.cs
@@ -19,8 +19,7 @@ namespace SME.SGP.Api.Middlewares
 
         public async Task InvokeAsync(HttpContext context, RequestDelegate next)
         {
-            if ((servicoToken.TokenPresente() && servicoToken.TokenAtivo())
-                || !servicoToken.TokenPresente())
+            if (!servicoToken.TokenPresente() || servicoToken.TokenAtivo())
             {
                 await next(context);
 

--- a/src/SME.SGP.Dados/Repositorios/RepositorioCache.cs
+++ b/src/SME.SGP.Dados/Repositorios/RepositorioCache.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Extensions.Caching.Distributed;
 using SME.SGP.Dominio.Interfaces;
+using SME.SGP.Infra;
 using System;
 using System.Threading.Tasks;
 
@@ -8,10 +9,12 @@ namespace SME.SGP.Dados.Repositorios
     public class RepositorioCache : IRepositorioCache
     {
         private readonly IDistributedCache distributedCache;
+        private readonly IServicoLog servicoLog;
 
-        public RepositorioCache(IDistributedCache distributedCache)
+        public RepositorioCache(IDistributedCache distributedCache, IServicoLog servicoLog)
         {
             this.distributedCache = distributedCache ?? throw new System.ArgumentNullException(nameof(distributedCache));
+            this.servicoLog = servicoLog ?? throw new System.ArgumentNullException(nameof(servicoLog));
         }
 
         public string Obter(string nomeChave)
@@ -20,9 +23,10 @@ namespace SME.SGP.Dados.Repositorios
             {
                 return distributedCache.GetString(nomeChave);
             }
-            catch (Exception)
+            catch (Exception ex)
             {
                 //Caso o cache esteja indisponível a aplicação precisa continuar funcionando mesmo sem o cache
+                servicoLog.Registrar(ex);
                 return null;
             }
         }
@@ -33,9 +37,10 @@ namespace SME.SGP.Dados.Repositorios
             {
                 await distributedCache.RemoveAsync(nomeChave);
             }
-            catch (Exception)
+            catch (Exception ex)
             {
                 //Caso o cache esteja indisponível a aplicação precisa continuar funcionando mesmo sem o cache
+                servicoLog.Registrar(ex);
             }
         }
 
@@ -46,9 +51,10 @@ namespace SME.SGP.Dados.Repositorios
                 await distributedCache.SetStringAsync(nomeChave, valor, new DistributedCacheEntryOptions()
                                                 .SetAbsoluteExpiration(TimeSpan.FromMinutes(minutosParaExpirar)));
             }
-            catch (Exception)
+            catch (Exception ex)
             {
                 //Caso o cache esteja indisponível a aplicação precisa continuar funcionando mesmo sem o cache
+                servicoLog.Registrar(ex);
             }
         }
     }


### PR DESCRIPTION
Quando ocorrer erro ao tentar acessar o Redis, será logado no Sentry, assim saberemos que estamos com problema no cache

[AB#6686](https://dev.azure.com/amcomgov/Novo%20SGP/_workitems/edit/6686)
