### PR TITLE
9400 - Validação de token mais atual do que o Cache

### DIFF
--- a/src/SME.SGP.Api/Controllers/AutenticacaoController.cs
+++ b/src/SME.SGP.Api/Controllers/AutenticacaoController.cs
@@ -127,12 +127,12 @@ namespace SME.SGP.Api.Controllers
 
         [HttpPost("revalidar")]
         [ProducesResponseType(typeof(RetornoBaseDto), 500)]
-        [ProducesResponseType(typeof(string), 200)]
+        [ProducesResponseType(typeof(UsuarioReinicioSenhaDto), 200)]
         public async Task<IActionResult> Revalidar()
         {
             var tokenRetorno = await comandosUsuario.RevalidarLogin();
 
-            if (tokenRetorno == string.Empty)
+            if (tokenRetorno == null)
                 return StatusCode(401);
 
             return Ok(tokenRetorno);

--- a/src/SME.SGP.Aplicacao/Comandos/ComandosUsuario.cs
+++ b/src/SME.SGP.Aplicacao/Comandos/ComandosUsuario.cs
@@ -191,10 +191,12 @@ namespace SME.SGP.Aplicacao
                 usuario.DefinirPerfilAtual(perfil);
 
                 servicoTokenJwt.RevogarToken(loginAtual);
+                var tokenStr = servicoTokenJwt.GerarToken(loginAtual, nomeLoginAtual, codigoRfAtual, perfil, listaPermissoes);
 
                 return new TrocaPerfilDto
                 {
-                    Token = servicoTokenJwt.GerarToken(loginAtual, nomeLoginAtual, codigoRfAtual, perfil, listaPermissoes),
+                    Token = tokenStr,
+                    DataHoraExpiracao = servicoTokenJwt.ObterDataHoraExpiracao(),
                     EhProfessor = usuario.EhProfessor(),
                     EhProfessorCj = usuario.EhProfessorCj(),
                     EhProfessorPoa = usuario.EhProfessorPoa()
@@ -219,7 +221,7 @@ namespace SME.SGP.Aplicacao
             return retorno;
         }
 
-        public async Task<string> RevalidarLogin()
+        public async Task<RevalidacaoTokenDto> RevalidarLogin()
         {
             // Obter Login do token atual
             var login = servicoTokenJwt.ObterLogin();
@@ -233,7 +235,7 @@ namespace SME.SGP.Aplicacao
             // Busca lista de permissões do EOL
             var permissionamentos = await servicoEOL.ObterPermissoesPorPerfil(guidPerfil);
             if (permissionamentos == null || !permissionamentos.Any())
-                return string.Empty;
+                return null;
 
             var listaPermissoes = permissionamentos
                 .Distinct()
@@ -242,7 +244,11 @@ namespace SME.SGP.Aplicacao
 
             servicoTokenJwt.RevogarToken(login);
 
-            return servicoTokenJwt.GerarToken(login, dadosUsuario.Nome, usuario.CodigoRf, usuario.PerfilAtual, listaPermissoes);
+            return new RevalidacaoTokenDto()
+            {
+                Token = servicoTokenJwt.GerarToken(login, dadosUsuario.Nome, usuario.CodigoRf, usuario.PerfilAtual, listaPermissoes),
+                DataHoraExpiracao = servicoTokenJwt.ObterDataHoraExpiracao()
+            };
         }
 
         public void Sair()

--- a/src/SME.SGP.Aplicacao/Comandos/ComandosUsuario.cs
+++ b/src/SME.SGP.Aplicacao/Comandos/ComandosUsuario.cs
@@ -152,6 +152,9 @@ namespace SME.SGP.Aplicacao
             retornoAutenticacaoEol.Item1.Token =
                 servicoTokenJwt.GerarToken(login, dadosUsuario.Nome, usuario.CodigoRf, retornoAutenticacaoEol.Item1.PerfisUsuario.PerfilSelecionado, listaPermissoes);
 
+            retornoAutenticacaoEol.Item1.DataHoraExpiracao = servicoTokenJwt.ObterDataHoraExpiracao();
+            var fromDate = servicoTokenJwt.ObterDataHoraCriacao();
+
             usuario.AtualizaUltimoLogin();
 
             repositorioUsuario.Salvar(usuario);

--- a/src/SME.SGP.Aplicacao/Interfaces/Comandos/IComandosUsuario.cs
+++ b/src/SME.SGP.Aplicacao/Interfaces/Comandos/IComandosUsuario.cs
@@ -22,7 +22,7 @@ namespace SME.SGP.Aplicacao
 
         Task<UsuarioReinicioSenhaDto> ReiniciarSenha(string codigoRf);
 
-        Task<string> RevalidarLogin();
+        Task<RevalidacaoTokenDto> RevalidarLogin();
 
         void Sair();
 

--- a/src/SME.SGP.Aplicacao/Interfaces/Servicos/IServicoTokenJwt.cs
+++ b/src/SME.SGP.Aplicacao/Interfaces/Servicos/IServicoTokenJwt.cs
@@ -17,6 +17,9 @@ namespace SME.SGP.Aplicacao
         bool TemPerfilNoToken(string guid);
         string ObterLogin();
 
+        DateTime ObterDataHoraExpiracao();
+        DateTime ObterDataHoraCriacao();
+
         Guid ObterPerfil();
     }
 }

--- a/src/SME.SGP.Infra/Dtos/RevalidacaoTokenDto.cs
+++ b/src/SME.SGP.Infra/Dtos/RevalidacaoTokenDto.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace SME.SGP.Infra
+{
+    public class RevalidacaoTokenDto
+    {
+        public DateTime DataHoraExpiracao { get; set; }
+        public string Token { get; set; }
+    }
+}

--- a/src/SME.SGP.Infra/Dtos/TrocaPerfilDto.cs
+++ b/src/SME.SGP.Infra/Dtos/TrocaPerfilDto.cs
@@ -1,10 +1,13 @@
-﻿namespace SME.SGP.Infra
+﻿using System;
+
+namespace SME.SGP.Infra
 {
     public class TrocaPerfilDto
     {
         public bool EhProfessor { get; set; }
         public bool EhProfessorCj { get; set; }
         public bool EhProfessorPoa { get; set; }
+        public DateTime DataHoraExpiracao { get; set; }
         public string Token { get; set; }
     }
 }

--- a/src/SME.SGP.Infra/Dtos/UsuarioAutenticacaoRetornoDto.cs
+++ b/src/SME.SGP.Infra/Dtos/UsuarioAutenticacaoRetornoDto.cs
@@ -13,6 +13,7 @@ namespace SME.SGP.Infra
         public bool Autenticado { get; set; }
         public bool ModificarSenha { get; set; }
         public PerfisPorPrioridadeDto PerfisUsuario { get; set; }
+        public DateTime DataHoraExpiracao { get; set; }
         public string Token { get; set; }
         public Guid UsuarioId { get; set; }
     }


### PR DESCRIPTION
- Tratar a validação de token ativo para que se o toquem atual for mais novo que o do cache, atualiza o cache e valida;
- Expor a data e hora de expiração do token para o client;
