### PR TITLE
10181 - Consulta Grade: Corrigido pesquisa de aulas no dia

### DIFF
--- a/src/SME.SGP.Aplicacao/Consultas/ConsultasGrade.cs
+++ b/src/SME.SGP.Aplicacao/Consultas/ConsultasGrade.cs
@@ -67,10 +67,10 @@ namespace SME.SGP.Aplicacao
             int horascadastradas;
 
             if (ehRegencia)
-                horascadastradas = await consultasAula.ObterQuantidadeAulasTurmaDiaProfessor(turma.ToString(), disciplina.ToString(), dataAula, codigoRf);
+                horascadastradas = await consultasAula.ObterQuantidadeAulasTurmaDiaProfessor(turma.CodigoTurma, disciplina.ToString(), dataAula, codigoRf);
             else
                 // Busca horas aula cadastradas para a disciplina na turma
-                horascadastradas = await consultasAula.ObterQuantidadeAulasTurmaSemanaProfessor(turma.ToString(), disciplina.ToString(), semana, codigoRf);
+                horascadastradas = await consultasAula.ObterQuantidadeAulasTurmaSemanaProfessor(turma.CodigoTurma, disciplina.ToString(), semana, codigoRf);
 
             return new GradeComponenteTurmaAulasDto
             {


### PR DESCRIPTION
Problema: Não esta considerando as aulas de regencia de classe no dia quando consulta a grade;
Motivo: Estava passando o objeto turma como string para o repositorio filtrar, consequentemente não encontrava aulas com o filtro passado;
Solução: Correção da passagem de parametros para a consulta de aulas no dia

[AB#9602](https://dev.azure.com/amcomgov/Novo%20SGP/_workitems/edit/9602)