### PR TITLE
10266 - Corrigido buscar de eventos concomitantes

### DIFF
--- a/src/SME.SGP.Dados/Repositorios/RepositorioEvento.cs
+++ b/src/SME.SGP.Dados/Repositorios/RepositorioEvento.cs
@@ -185,10 +185,10 @@ namespace SME.SGP.Dados.Repositorios
             }));
         }
 
-        public bool ExisteEventoNaMesmaDataECalendario(DateTime dataInicio, long tipoCalendarioId)
+        public bool ExisteEventoNaMesmaDataECalendario(DateTime dataInicio, long tipoCalendarioId, long eventoId)
         {
-            var query = "select 1 from evento where data_inicio = @dataInicio and tipo_calendario_id = @tipoCalendarioId;";
-            return database.Conexao.QueryFirstOrDefault<bool>(query, new { dataInicio, tipoCalendarioId });
+            var query = "select 1 from evento where data_inicio = @dataInicio and tipo_calendario_id = @tipoCalendarioId and id <> :eventoId;";
+            return database.Conexao.QueryFirstOrDefault<bool>(query, new { dataInicio, tipoCalendarioId, eventoId });
         }
 
         public bool ExisteEventoPorEventoTipoId(long eventoTipoId)

--- a/src/SME.SGP.Dominio.Interfaces/Repositorios/IRepositorioEvento.cs
+++ b/src/SME.SGP.Dominio.Interfaces/Repositorios/IRepositorioEvento.cs
@@ -13,7 +13,7 @@ namespace SME.SGP.Dominio.Interfaces
 
         Task<IEnumerable<Evento>> EventosNosDiasETipo(DateTime dataInicio, DateTime dataFim, TipoEvento tipoEventoCodigo, long tipoCalendarioId, string UeId, string DreId);
 
-        bool ExisteEventoNaMesmaDataECalendario(DateTime dataInicio, long tipoCalendarioId);
+        bool ExisteEventoNaMesmaDataECalendario(DateTime dataInicio, long tipoCalendarioId, long eventoId);
 
         bool ExisteEventoPorEventoTipoId(long eventoTipoId);
 

--- a/src/SME.SGP.Dominio.Servicos/ServicoEvento.cs
+++ b/src/SME.SGP.Dominio.Servicos/ServicoEvento.cs
@@ -103,7 +103,7 @@ namespace SME.SGP.Dominio.Servicos
 
             if (!evento.PermiteConcomitancia())
             {
-                var existeOutroEventoNaMesmaData = repositorioEvento.ExisteEventoNaMesmaDataECalendario(evento.DataInicio, evento.TipoCalendarioId);
+                var existeOutroEventoNaMesmaData = repositorioEvento.ExisteEventoNaMesmaDataECalendario(evento.DataInicio, evento.TipoCalendarioId, evento.Id);
                 if (existeOutroEventoNaMesmaData)
                 {
                     throw new NegocioException("Não é permitido cadastrar um evento nesta data pois esse tipo de evento não permite concomitância.");


### PR DESCRIPTION
Corrigido buscar de eventos concomitantes para desconsiderar o evento atual quando estiver salvando uma edição;

[AB#9990](https://dev.azure.com/amcomgov/Novo%20SGP/_workitems/edit/9990)