### PR TITLE
10274 - Corrigido chamada de api para alteração 

### DIFF
--- a/src/SME.SGP.Api/Controllers/TipoCalendarioController.cs
+++ b/src/SME.SGP.Api/Controllers/TipoCalendarioController.cs
@@ -56,7 +56,7 @@ namespace SME.SGP.Api.Controllers
         [HttpPost]
         [ProducesResponseType(200)]
         [ProducesResponseType(typeof(RetornoBaseDto), 500)]
-        //[Permissao(Permissao.TCE_I, Policy = "Bearer")]
+        [Permissao(Permissao.TCE_I, Policy = "Bearer")]
         public async Task<IActionResult> Incluir([FromBody]TipoCalendarioDto dto)
         {
             await comandos.Incluir(dto);

--- a/src/SME.SGP.WebClient/public/configuracoes/variaveis.json
+++ b/src/SME.SGP.WebClient/public/configuracoes/variaveis.json
@@ -1,3 +1,3 @@
 {
-  "API_URL": "https://hom-novosgp.sme.prefeitura.sp.gov.br/api"
+  "API_URL": "https://localhost:5001/api"
 }

--- a/src/SME.SGP.WebClient/src/paginas/CalendarioEscolar/TipoCalendarioEscolar/tipoCalendarioEscolarForm.js
+++ b/src/SME.SGP.WebClient/src/paginas/CalendarioEscolar/TipoCalendarioEscolar/tipoCalendarioEscolarForm.js
@@ -160,8 +160,13 @@ const TipoCalendarioEscolarForm = ({ match }) => {
   const onClickCadastrar = async valoresForm => {
     valoresForm.id = idTipoCalendario || 0;
     valoresForm.anoLetivo = anoLetivo;
-    const cadastrado = await api
-      .post('v1/calendarios/tipos', valoresForm)
+    var metodo = idTipoCalendario ? 'put' : 'post';
+    var url = 'v1/calendarios/tipos';
+    if (idTipoCalendario)
+      url += '/' + idTipoCalendario;
+
+    const cadastrado = await api[metodo]
+      (url, valoresForm)
       .catch(e => erros(e));
     if (cadastrado) {
       sucesso('Suas informações foram salvas com sucesso.');
@@ -214,7 +219,7 @@ const TipoCalendarioEscolarForm = ({ match }) => {
       <Cabecalho
         pagina={`${
           idTipoCalendario > 0 ? 'Alterar' : 'Cadastro do'
-        } Tipo de Calendário Escolar`}
+          } Tipo de Calendário Escolar`}
       />
       <Card>
         <Formik
@@ -330,8 +335,8 @@ const TipoCalendarioEscolarForm = ({ match }) => {
             alteradoRf={auditoria.alteradoRf}
           />
         ) : (
-          ''
-        )}
+            ''
+          )}
       </Card>
     </>
   );


### PR DESCRIPTION
O botão alterar estava chamando o post ao invés do put como esperado para alteração. Por este motivo estava duplicando os registros;

[AB#8330](https://dev.azure.com/amcomgov/Novo%20SGP/_workitems/edit/8330)