### PR TITLE
Correção de expiração de sessão

### DIFF
--- a/src/SME.SGP.WebClient/public/configuracoes/variaveis.json
+++ b/src/SME.SGP.WebClient/public/configuracoes/variaveis.json
@@ -1,3 +1,3 @@
 {
-  "API_URL": "https://localhost:5001/api"
+  "API_URL": "https://dev-novosgp.sme.prefeitura.sp.gov.br/api"
 }

--- a/src/SME.SGP.WebClient/src/componentes-sgp/perfil.js
+++ b/src/SME.SGP.WebClient/src/componentes-sgp/perfil.js
@@ -93,6 +93,10 @@ const Perfil = props => {
     store.dispatch(removerTurma());
   };
 
+  const cancelarRequisicoesPendentes = () => {
+    api.CancelarRequisicoes('Cancelado pelo usuário');
+  };
+
   const gravarPerfilSelecionado = perfil => {
     if (perfil) {
       const perfilNovo = perfilStore.perfis.filter(
@@ -164,6 +168,11 @@ const Perfil = props => {
     }
   };
 
+  const onClickPerfil = e => {
+    cancelarRequisicoesPendentes();
+    gravarPerfilSelecionado(e.currentTarget.accessKey);
+  };
+
   const onClickBotao = () => {
     if (perfilStore.perfis.length > 1) {
       setarOcultaPerfis(!ocultaPerfis);
@@ -206,9 +215,7 @@ const Perfil = props => {
             {perfilStore.perfis.map(item => (
               <Item
                 key={item.codigoPerfil}
-                onClick={e => {
-                  gravarPerfilSelecionado(e.currentTarget.accessKey);
-                }}
+                onClick={onClickPerfil}
                 accessKey={item.codigoPerfil}
               >
                 <td style={{ width: '20px' }}>

--- a/src/SME.SGP.WebClient/src/componentes-sgp/tempoExpiracaoSessao/tempoExpiracaoSessao.js
+++ b/src/SME.SGP.WebClient/src/componentes-sgp/tempoExpiracaoSessao/tempoExpiracaoSessao.js
@@ -76,10 +76,10 @@ const TempoExpiracaoSessao = () => {
     expiraEm: '',
     diferenca: '',
   });
+  const [botaoDesabilitado, setBotaoDesabilitado] = useState(false);
 
   const calcularTempoExpiracao = useCallback(() => {
     const diferenca = +new Date(dataHoraExpiracao) - +new Date();
-
     if (diferenca > 0) {
       const quinzeMinutos = 900000;
       const tempoParaExibir =
@@ -119,10 +119,16 @@ const TempoExpiracaoSessao = () => {
   }, [deslogarDoUsuario, tempoParaExpirar]);
 
   const revalidarAutenticacao = async () => {
+    setBotaoDesabilitado(true);
+    api.CancelarRequisicoes('Cancelado pelo usuário');
+
     const autenticado = await api
       .post('v1/autenticacao/revalidar')
-      .catch(e => erros(e));
+      .catch(e => erros(e))
+      .finally(() => setBotaoDesabilitado(false));
+
     setMostraTempoExpiracao(false);
+
     if (autenticado && autenticado.data && autenticado.data.token) {
       dispatch(
         salvarLoginRevalidado({
@@ -155,6 +161,7 @@ const TempoExpiracaoSessao = () => {
               border
               className="botao-refresh"
               onClick={revalidarAutenticacao}
+              disabled={botaoDesabilitado}
             />
           </CaixaTempoExpiracao>
         </Container>


### PR DESCRIPTION
Este pull request contempla uma correção para evitar expirar a sessão de forma indevida.

Sempre que trocar de perfil ou renovar a sessão, todas as requisições pendentes serão canceladas, para evitar que elas sejam realizadas com o token antigo gerando um erro 401 indevido.

[AB#10159](https://dev.azure.com/amcomgov/c1dcf343-60ee-40b6-a30a-3b9c12c6d220/_workitems/edit/10159)