### PR TITLE
11667 - Notificação Frequencia: Ajuste na pesquisa de turmas

### DIFF
--- a/src/SME.SGP.Dominio.Servicos/ServicoNotificacaoFrequencia.cs
+++ b/src/SME.SGP.Dominio.Servicos/ServicoNotificacaoFrequencia.cs
@@ -225,7 +225,11 @@ namespace SME.SGP.Dominio.Servicos
                 // Carrega dados das turmas (ue e dre)
                 var turmas = new List<Turma>();
                 alunosAusentes.Select(a => a.TurmaId).Distinct().ToList()
-                    .ForEach(turmaId => turmas.Add(repositorioTurma.ObterTurmaComUeEDrePorId(turmaId)));
+                    .ForEach(turmaId =>
+                    {
+                        if (turmaId != null)
+                            turmas.Add(repositorioTurma.ObterTurmaComUeEDrePorId(turmaId));
+                    });
 
                 var percentualFrequenciaFund = double.Parse(repositorioParametrosSistema.ObterValorPorTipoEAno(TipoParametroSistema.CompensacaoAusenciaPercentualFund2));
                 var percentualFrequenciaRegencia = double.Parse(repositorioParametrosSistema.ObterValorPorTipoEAno(TipoParametroSistema.CompensacaoAusenciaPercentualRegenciaClasse));


### PR DESCRIPTION
Ajuste na pesquisa de turmas, para que os registros históricos que não possuem turma sejam ignorados. Já que não será possível montar a mensagem e o problema só ocorrerá em ambiente dev

[AB#11666](https://dev.azure.com/amcomgov/Novo%20SGP/_workitems/edit/11666)