### PR TITLE
Fix para esconder checkbox de histórico no filtro

### DIFF
--- a/src/SME.SGP.WebClient/src/componentes-sgp/filtro/index.js
+++ b/src/SME.SGP.WebClient/src/componentes-sgp/filtro/index.js
@@ -826,7 +826,7 @@ const Filtro = () => {
             ref={divBuscaRef}
             className="container d-block position-absolute bg-white shadow rounded mt-1 px-3 pt-4 pb-1"
           >
-            <div className="form-row">
+            <div className="form-row d-none">
               <Grid cols={12} className="form-group">
                 <Checkbox
                   checked={consideraHistorico}


### PR DESCRIPTION
Alteração temporária para sanar problema com professores que estão conseguindo alterar dados passados no sistema