### PR TITLE
Correção recuperação paralela

### DIFF
--- a/scripts/V133__AJUSTE_RECUPERACAO_PARALELA4.SQL
+++ b/scripts/V133__AJUSTE_RECUPERACAO_PARALELA4.SQL
@@ -1,0 +1,2 @@
+update parametros_sistema set descricao = 'Percentual de frequência onde a recuperação paralela considera abaixo do limite para alunos pouco frequentes' 
+where nome = 'RecuperacaoParalelaPoucoFrequente';


### PR DESCRIPTION
Correção Recuperação paralela Acompanhamento, banco de dados, tabela parametros_sistema, exibe a palavra 'pouco' de maneira incorreto

[AB#11976](https://dev.azure.com/amcomgov/c1dcf343-60ee-40b6-a30a-3b9c12c6d220/_workitems/edit/11976)