### PR TITLE
12578 - Apresentar percentual 0.00 quando não houver valor

### DIFF
--- a/src/SME.SGP.WebClient/src/paginas/DiarioClasse/CompensacaoAusencia/listasAlunos/listaAlunos.js
+++ b/src/SME.SGP.WebClient/src/paginas/DiarioClasse/CompensacaoAusencia/listasAlunos/listaAlunos.js
@@ -10,7 +10,7 @@ const ListaAlunos = props => {
   const montaExibicaoPercentual = (frequencia, dadosAluno) => {
     const frequenciaArredondada = frequencia
       ? Number(frequencia).toFixed(2)
-      : '';
+      : '0.00';
     if (dadosAluno.alerta) {
       return (
         <>
@@ -58,7 +58,7 @@ const ListaAlunos = props => {
           columns={colunasListaAlunos}
           dataSource={lista}
           selectMultipleRows
-          onClickRow={() => {}}
+          onClickRow={() => { }}
           pagination={false}
           pageSize={9999}
         />
@@ -76,7 +76,7 @@ ListaAlunos.propTypes = {
 ListaAlunos.defaultProps = {
   lista: [],
   idsAlunos: [],
-  onSelectRow: () => {},
+  onSelectRow: () => { },
 };
 
 export default ListaAlunos;


### PR DESCRIPTION
Quando o percentual é zero não estava exibindo valor no grid

[AB#12128](https://dev.azure.com/amcomgov/Novo%20SGP/_workitems/edit/12128)
