### PR TITLE
12133 - Erro ao salvar exclusão de evento

### DIFF
--- a/src/SME.SGP.Dados/Repositorios/RepositorioEvento.cs
+++ b/src/SME.SGP.Dados/Repositorios/RepositorioEvento.cs
@@ -124,6 +124,7 @@ namespace SME.SGP.Dados.Repositorios
             query.AppendLine("e.status,");
             query.AppendLine("e.wf_aprovacao_id as WorkflowAprovacaoId,");
             query.AppendLine("e.tipo_perfil_cadastro as TipoPerfilCadastro,");
+            query.AppendLine("e.letivo,");
             query.AppendLine("et.id as TipoEventoId,");
             query.AppendLine("et.id,");
             query.AppendLine("et.codigo,");


### PR DESCRIPTION
Erro ao salvar exclusão de evento pois a propriedade Letivo não era carregada

[AB#12133](https://dev.azure.com/amcomgov/Novo%20SGP/_workitems/edit/12133)