### PR TITLE
12133 - Corrigido pesquisa de eventos para considerar apenas mesmo in…

### DIFF
--- a/src/SME.SGP.Dados/Repositorios/RepositorioEvento.cs
+++ b/src/SME.SGP.Dados/Repositorios/RepositorioEvento.cs
@@ -99,7 +99,7 @@ namespace SME.SGP.Dados.Repositorios
             return retorno == null || retorno.Sum() == 0;
         }
 
-        public async Task<IEnumerable<Evento>> EventosNosDiasETipo(DateTime dataInicio, DateTime dataFim, TipoEvento tipoEventoCodigo, long tipoCalendarioId, string UeId, string DreId)
+        public async Task<IEnumerable<Evento>> EventosNosDiasETipo(DateTime dataInicio, DateTime dataFim, TipoEvento tipoEventoCodigo, long tipoCalendarioId, string UeId, string DreId, bool utilizarRangeDatas = true)
         {
             var query = new StringBuilder();
 
@@ -147,10 +147,18 @@ namespace SME.SGP.Dados.Repositorios
             if (!string.IsNullOrEmpty(DreId))
                 query.AppendLine("and e.dre_id = @dreId");
 
-            query.AppendLine("and ((e.data_inicio <= TO_DATE(@dataInicio, 'yyyy/mm/dd') and e.data_fim >= TO_DATE(@dataInicio, 'yyyy/mm/dd'))");
-            query.AppendLine("or (e.data_inicio <= TO_DATE(@dataFim, 'yyyy/mm/dd') and e.data_fim >= TO_DATE(@dataFim, 'yyyy/mm/dd'))");
-            query.AppendLine("or (e.data_inicio >= TO_DATE(@dataInicio, 'yyyy/mm/dd') and e.data_fim <= TO_DATE(@dataFim, 'yyyy/mm/dd'))");
-            query.AppendLine(")");
+            if (utilizarRangeDatas)
+            {
+                query.AppendLine("and ((e.data_inicio <= TO_DATE(@dataInicio, 'yyyy/mm/dd') and e.data_fim >= TO_DATE(@dataInicio, 'yyyy/mm/dd'))");
+                query.AppendLine("or (e.data_inicio <= TO_DATE(@dataFim, 'yyyy/mm/dd') and e.data_fim >= TO_DATE(@dataFim, 'yyyy/mm/dd'))");
+                query.AppendLine("or (e.data_inicio >= TO_DATE(@dataInicio, 'yyyy/mm/dd') and e.data_fim <= TO_DATE(@dataFim, 'yyyy/mm/dd'))");
+                query.AppendLine(")");
+            }
+            else
+            {
+                query.AppendLine("and e.data_inicio = TO_DATE(@dataInicio, 'yyyy/mm/dd') ");
+                query.AppendLine("and e.data_fim = TO_DATE(@dataFim, 'yyyy/mm/dd')");
+            }
             query.AppendLine("and e.tipo_calendario_id = @tipoCalendarioId");
 
             var lookup = new Dictionary<long, Evento>();

--- a/src/SME.SGP.Dominio.Interfaces/Repositorios/IRepositorioEvento.cs
+++ b/src/SME.SGP.Dominio.Interfaces/Repositorios/IRepositorioEvento.cs
@@ -11,7 +11,7 @@ namespace SME.SGP.Dominio.Interfaces
 
         bool EhEventoLetivoPorTipoDeCalendarioDataDreUe(long tipoCalendarioId, DateTime data, string dreId, string ueId);
 
-        Task<IEnumerable<Evento>> EventosNosDiasETipo(DateTime dataInicio, DateTime dataFim, TipoEvento tipoEventoCodigo, long tipoCalendarioId, string UeId, string DreId);
+        Task<IEnumerable<Evento>> EventosNosDiasETipo(DateTime dataInicio, DateTime dataFim, TipoEvento tipoEventoCodigo, long tipoCalendarioId, string UeId, string DreId, bool utilizarRangeDatas = true);
 
         bool ExisteEventoNaMesmaDataECalendario(DateTime dataInicio, long tipoCalendarioId, long eventoId);
 

--- a/src/SME.SGP.Dominio.Interfaces/Servicos/IServicoEvento.cs
+++ b/src/SME.SGP.Dominio.Interfaces/Servicos/IServicoEvento.cs
@@ -10,6 +10,8 @@ namespace SME.SGP.Dominio.Interfaces
 
         Task<string> Salvar(Evento evento, bool alterarRecorrenciaCompleta = false, bool dataConfirmada = false, bool unitOfWorkJaEmUso = false);
 
+        Task Excluir(Evento evento);
+
         void SalvarEventoFeriadosAoCadastrarTipoCalendario(TipoCalendario tipoCalendario);
 
         void SalvarRecorrencia(Evento evento, DateTime dataInicial, DateTime? dataFinal, int? diaDeOcorrencia, IEnumerable<DayOfWeek> diasDaSemana, PadraoRecorrencia padraoRecorrencia, PadraoRecorrenciaMensal? padraoRecorrenciaMensal, int repeteACada);

--- a/src/SME.SGP.Dominio.Servicos/ServicoEvento.cs
+++ b/src/SME.SGP.Dominio.Servicos/ServicoEvento.cs
@@ -523,5 +523,11 @@ namespace SME.SGP.Dominio.Servicos
             var eventos = await repositorioEvento.ObterEventosPorTipoETipoCalendario((long)TipoEvento.OrganizacaoEscolar, evento.TipoCalendarioId);
             evento.VerificaSeEventoAconteceJuntoComOrganizacaoEscolar(eventos, usuario);
         }
+
+        public async Task Excluir(Evento evento)
+        {
+            evento.Excluir();
+            repositorioEvento.Salvar(evento);
+        }
     }
 }

--- a/src/SME.SGP.Dominio.Servicos/ServicoFechamentoReabertura.cs
+++ b/src/SME.SGP.Dominio.Servicos/ServicoFechamentoReabertura.cs
@@ -160,7 +160,7 @@ namespace SME.SGP.Dominio.Servicos
 
         private async Task AtualizoEvento(FechamentoReabertura fechamentoReaberturasParaAtualizar, DateTime inicio, DateTime fim)
         {
-            var eventosParaAtualizar = await repositorioEvento.EventosNosDiasETipo(fechamentoReaberturasParaAtualizar.Inicio, fechamentoReaberturasParaAtualizar.Fim, TipoEvento.FechamentoBimestre, fechamentoReaberturasParaAtualizar.TipoCalendarioId, fechamentoReaberturasParaAtualizar.Ue.CodigoUe, fechamentoReaberturasParaAtualizar.Dre.CodigoDre);
+            var eventosParaAtualizar = await repositorioEvento.EventosNosDiasETipo(fechamentoReaberturasParaAtualizar.Inicio, fechamentoReaberturasParaAtualizar.Fim, TipoEvento.FechamentoBimestre, fechamentoReaberturasParaAtualizar.TipoCalendarioId, fechamentoReaberturasParaAtualizar.Ue.CodigoUe, fechamentoReaberturasParaAtualizar.Dre.CodigoDre, false);
             if (eventosParaAtualizar != null && eventosParaAtualizar.Any())
             {
                 var eventoParaAtualizar = eventosParaAtualizar.FirstOrDefault();
@@ -185,12 +185,11 @@ namespace SME.SGP.Dominio.Servicos
             }
             if (fechamentoReaberturaParaExcluir.EhParaUe())
             {
-                var eventosParaExcluir = await repositorioEvento.EventosNosDiasETipo(fechamentoReaberturaParaExcluir.Inicio, fechamentoReaberturaParaExcluir.Fim, TipoEvento.FechamentoBimestre, fechamentoReaberturaParaExcluir.TipoCalendarioId, fechamentoReaberturaParaExcluir.Ue.CodigoUe, fechamentoReaberturaParaExcluir.Dre.CodigoDre);
+                var eventosParaExcluir = await repositorioEvento.EventosNosDiasETipo(fechamentoReaberturaParaExcluir.Inicio, fechamentoReaberturaParaExcluir.Fim, TipoEvento.FechamentoBimestre, fechamentoReaberturaParaExcluir.TipoCalendarioId, fechamentoReaberturaParaExcluir.Ue.CodigoUe, fechamentoReaberturaParaExcluir.Dre.CodigoDre, false);
                 if (eventosParaExcluir != null && eventosParaExcluir.Any())
                 {
                     var eventoParaExcluir = eventosParaExcluir.FirstOrDefault();
-                    eventoParaExcluir.Excluir();
-                    await servicoEvento.Salvar(eventoParaExcluir, false, false, true);
+                    await servicoEvento.Excluir(eventoParaExcluir);
                 }
             }
         }


### PR DESCRIPTION
Corrigido pesquisa de eventos para considerar apenas mesmo inicio e fim e não o range;
A pesquisa pelo range de datas fazia com que o evento de abertura também fosse localizado e tentava exclui-lo;

[AB#12133](https://dev.azure.com/amcomgov/Novo%20SGP/_workitems/edit/12133)