### PR TITLE
fix/18394

### DIFF
--- a/src/Bibliotecas/SME.Background.Hangfire/DependencyInjection/HangfireActivator.cs
+++ b/src/Bibliotecas/SME.Background.Hangfire/DependencyInjection/HangfireActivator.cs
@@ -1,4 +1,6 @@
 ﻿using Hangfire;
+using MediatR;
+using SME.SGP.Aplicacao;
 using System;
 
 namespace SME.Background.Hangfire
@@ -6,15 +8,19 @@ namespace SME.Background.Hangfire
     public class HangfireActivator : JobActivator
     {
         private readonly IServiceProvider _serviceProvider;
+        private readonly IMediator mediator;
 
-        public HangfireActivator(IServiceProvider serviceProvider)
+        public HangfireActivator(IServiceProvider serviceProvider, IMediator mediator)
         {
             _serviceProvider = serviceProvider;
+            this.mediator = mediator ?? throw new ArgumentNullException(nameof(mediator));
         }
 
         public override object ActivateJob(Type jobType)
         {
-            return _serviceProvider.GetService(jobType);
+            if (jobType.Name == "HangfireMediator")
+                return new HangfireMediator(mediator);
+            else return _serviceProvider.GetService(jobType);
         }
     }
 }

--- a/src/Bibliotecas/SME.Background.Hangfire/Worker.cs
+++ b/src/Bibliotecas/SME.Background.Hangfire/Worker.cs
@@ -76,8 +76,8 @@ namespace SME.Background.Hangfire
                 .UseSimpleAssemblyNameTypeSerializer()
                 .UseLogProvider<SentryLogProvider>(new SentryLogProvider())
                 .UseRecommendedSerializerSettings()
-                .UseActivator(new HangfireActivator(serviceCollection.BuildServiceProvider()))
-                .UseActivator(new MediatRJobActivator(mediator))
+                .UseActivator(new HangfireActivator(serviceCollection.BuildServiceProvider(), mediator))
+                //.UseActivator(new MediatRJobActivator(mediator))
                 .UseFilter<AutomaticRetryAttribute>(new AutomaticRetryAttribute() { Attempts = 0 })
                 .UsePostgreSqlStorage(connectionString, new PostgreSqlStorageOptions()
                 {


### PR DESCRIPTION
removendo a injeção do hangfire direto na iniciliazação e botando a decisão para ser em tempo de execução

[AB#18380](https://dev.azure.com/amcomgov/c1dcf343-60ee-40b6-a30a-3b9c12c6d220/_workitems/edit/18380)