### PR TITLE
Foi retirado o NumeroAlunoChamada 

### DIFF
--- a/src/SME.SGP.Aplicacao/Queries/Aluno/ObterAlunosPorCodigoEolNome/ObterAlunosPorCodigoEolNomeQueryHandler.cs
+++ b/src/SME.SGP.Aplicacao/Queries/Aluno/ObterAlunosPorCodigoEolNome/ObterAlunosPorCodigoEolNomeQueryHandler.cs
@@ -40,7 +40,6 @@ namespace SME.SGP.Aplicacao.Queries.Aluno.ObterAlunosPorCodigoEolNome
                 yield return new AlunoSimplesDto()
                 {
                     Codigo = alunoEOL.CodigoAluno,
-                    NumeroChamada = alunoEOL.NumeroAlunoChamada,
                     Nome = alunoEOL.NomeAluno
                 };
             }


### PR DESCRIPTION
[AB#20074](https://dev.azure.com/amcomgov/c1dcf343-60ee-40b6-a30a-3b9c12c6d220/_workitems/edit/20074)
Foi retirado o NumeroAlunoChamada pois não estava sendo utilizado e causava duplicidade nos registros