### PR TITLE
Bug: 20438

### DIFF
--- a/src/SME.SGP.Dados/Repositorios/RepositorioTurma.cs
+++ b/src/SME.SGP.Dados/Repositorios/RepositorioTurma.cs
@@ -1,14 +1,14 @@
 ﻿using Dapper;
 using Dommel;
+using Sentry;
 using SME.SGP.Dominio;
 using SME.SGP.Dominio.Interfaces;
 using SME.SGP.Infra;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.CompilerServices;
-using System.Threading.Tasks;
 using System.Text;
+using System.Threading.Tasks;
 
 namespace SME.SGP.Dados.Repositorios
 {
@@ -50,7 +50,7 @@ namespace SME.SGP.Dados.Repositorios
                         etapa_eja = @etapaEja,
                         data_inicio = @dataInicio
                     where
-	                    id = @id;";
+	                    id = @id;";        
 
         private const string Delete = @"
                     delete from public.compensacao_ausencia_aluno
@@ -93,22 +93,26 @@ namespace SME.SGP.Dados.Repositorios
 
                     delete from public.fechamento_turma
                     where turma_id in (#queryIdsTurmasForaListaCodigos);
-
                   
                     delete from public.frequencia_aluno
                     where turma_id in (#codigosTurmasARemover);
 
                     delete from public.diario_bordo
+                    where aula_id in (#queryIdsAulasTurmasForaListaCodigos);         
+                    
+                    delete from public.notificacao_frequencia
+                    where aula_id in (#queryIdsAulasTurmasForaListaCodigos);
+
+                    delete from public.registro_frequencia
                     where aula_id in (#queryIdsAulasTurmasForaListaCodigos);
 
                     delete from public.aula
                     where id in (#queryIdsAulasTurmasForaListaCodigos);
                     
                     delete from public.turma
-                    where not historica 
-                        and turma_id not in (#ids);";
+                    where turma_id in (#codigosTurmasARemover);";
 
-        private const string QueryIdsTurmasForaListaCodigos = "select id from public.turma where not historica and turma_id not in (#ids)";
+        private const string QueryIdsTurmasForaListaCodigos = "select id from public.turma where turma_id in (#codigosTurmasARemover)";
 
         private const string QueryIdsFechamentoTurmaDisciplinaTurmasForaListaCodigos = @"select id
                                                                                          from public.fechamento_turma_disciplina
@@ -130,7 +134,7 @@ namespace SME.SGP.Dados.Repositorios
 
         private const string QueryAulasTurmasForaListaCodigos = @"select id from public.aula where turma_id in (#codigosTurmasARemover)";
 
-        private const string QueryCodigosTurmasForaListaCodigos = "select turma_id from public.turma where not historica and turma_id not in (#ids)";
+        private const string QueryDefinirTurmaHistorica = "update public.turma set historica = true where turma_id in (#codigosTurmasParaHistorico);";        
 
         private readonly ISgpContext contexto;
 
@@ -289,7 +293,11 @@ namespace SME.SGP.Dados.Repositorios
         {
             List<Turma> resultado = new List<Turma>();
 
-            await RemoverTurmasExtintasAsync(entidades);
+            var anoLetivoConsiderado = (from e in entidades
+                                        orderby e.AnoLetivo descending
+                                        select e.AnoLetivo).Last();
+
+            await AtualizarRemoverTurmasExtintasAsync(entidades, anoLetivoConsiderado);
 
             for (int i = 0; i < entidades.Count(); i = i + 900)
             {
@@ -404,22 +412,61 @@ namespace SME.SGP.Dados.Repositorios
             return turmas;
         }
 
-        private async Task RemoverTurmasExtintasAsync(IEnumerable<Turma> entidades)
+        private async Task AtualizarRemoverTurmasExtintasAsync(IEnumerable<Turma> entidades, int anoLetivo)
         {
-            var codigosTurmas = entidades.Select(e => $"'{e.CodigoTurma}'")?.ToArray();
+            var codigosTurmas = entidades.OrderBy(e => e.CodigoTurma).Select(e => $"'{e.CodigoTurma}'")?.ToArray();
             var listaTurmas = string.Join(",", codigosTurmas);
 
-            var sql = Delete.Replace("#queryIdsConselhoClasseTurmasForaListaCodigos", QueryIdsConselhoClasseTurmasForaListaCodigos)
-                                .Replace("#queryFechamentoAlunoTurmasForaListaCodigos", QueryFechamentoAlunoTurmasForaListaCodigos)
-                                .Replace("#queryIdsFechamentoTurmaTurmasForaListaCodigos", QueryIdsFechamentoTurmaTurmasForaListaCodigos)
-                                .Replace("#queryIdsFechamentoTurmaDisciplinaTurmasForaListaCodigos", QueryIdsFechamentoTurmaDisciplinaTurmasForaListaCodigos)
-                                .Replace("#queryIdsTurmasForaListaCodigos", QueryIdsTurmasForaListaCodigos)
-                                .Replace("#queryIdsAulasTurmasForaListaCodigos", QueryAulasTurmasForaListaCodigos)
-                                .Replace("#queryCodigosTurmasForaListaCodigos", QueryCodigosTurmasForaListaCodigos)
-                                .Replace("#codigosTurmasARemover", QueryCodigosTurmasForaListaCodigos)
-                                .Replace("#ids", listaTurmas);
-            await contexto.Conexao
-                .ExecuteAsync(sql);
+            var sqlQueryAtualizarTurmasComoHistoricas = QueryDefinirTurmaHistorica
+                .Replace("#codigosTurmasParaHistorico", GerarQueryCodigosTurmasForaLista(anoLetivo, true));
+
+            var sqlExcluirTurmas = Delete.Replace("#queryIdsConselhoClasseTurmasForaListaCodigos", QueryIdsConselhoClasseTurmasForaListaCodigos)
+                                         .Replace("#queryFechamentoAlunoTurmasForaListaCodigos", QueryFechamentoAlunoTurmasForaListaCodigos)
+                                         .Replace("#queryIdsFechamentoTurmaTurmasForaListaCodigos", QueryIdsFechamentoTurmaTurmasForaListaCodigos)
+                                         .Replace("#queryIdsFechamentoTurmaDisciplinaTurmasForaListaCodigos", QueryIdsFechamentoTurmaDisciplinaTurmasForaListaCodigos)
+                                         .Replace("#queryIdsTurmasForaListaCodigos", QueryIdsTurmasForaListaCodigos)
+                                         .Replace("#queryIdsAulasTurmasForaListaCodigos", QueryAulasTurmasForaListaCodigos)                            
+                                         .Replace("#codigosTurmasARemover", GerarQueryCodigosTurmasForaLista(anoLetivo, false));
+
+            var transacao = contexto.Conexao.BeginTransaction();
+
+            try
+            {
+                var parametros = new { idsTurmas  = listaTurmas };
+
+                await contexto.Conexao
+                    .ExecuteAsync(sqlQueryAtualizarTurmasComoHistoricas, parametros, transacao);
+
+                await contexto.Conexao
+                    .ExecuteAsync(sqlExcluirTurmas, parametros, transacao);              
+
+                transacao.Commit();
+            }
+            catch (Exception ex)
+            {
+                var erro = new Exception("Erro ao atualizar ou excluir turmas extintas", ex);
+                SentrySdk.CaptureException(erro);
+                transacao.Rollback();                
+            }            
         }
+
+        private string GerarQueryCodigosTurmasForaLista(int anoLetivo, bool definirTurmasComoHistorica) =>
+            $@"select distinct t.turma_id
+	                from turma t
+		                inner join tipo_calendario tc
+			                on t.ano_letivo = tc.ano_letivo and
+			                   t.modalidade_codigo = t.modalidade_codigo 
+		                inner join periodo_escolar pe
+			                on tc.id = pe.tipo_calendario_id 			
+		                inner join (select id, data_inicio, modalidade_codigo
+					                    from turma
+					                where not historica and
+						                  turma_id not in (@idsTurmas)) t2
+			                on t.id = t2.id and
+			                   t.modalidade_codigo = t2.modalidade_codigo
+                where t.ano_letivo = {anoLetivo} and
+                      not t.historica and
+	                  pe.bimestre = 1 and                      
+	                  current_date {(definirTurmasComoHistorica ? ">=" : "<")} pe.periodo_inicio"; //Turmas que deram início após o 1º bimestre serão marcadas como histórica
     }
 }


### PR DESCRIPTION
Ajuste na funcionalidade de turmas extintas, considerando as novas regras.
Turmas extintas após início do ano letivo, considerando o inicio do 1º bimestre serão marcadas como hisórico. As turmas anteriores a essa data serão excluídas, assim como os dados relacionados.