### PR TITLE
fix/25447

### DIFF
--- a/src/SME.SGP.Aplicacao/Queries/ComponentesCurriculares/Regencia/ObterComponentesCurricularesRegenciaPorAnoETurno/ObterComponentesCurricularesRegenciaPorAnoETurnoQuery.cs
+++ b/src/SME.SGP.Aplicacao/Queries/ComponentesCurriculares/Regencia/ObterComponentesCurricularesRegenciaPorAnoETurno/ObterComponentesCurricularesRegenciaPorAnoETurnoQuery.cs
@@ -24,9 +24,6 @@ namespace SME.SGP.Aplicacao
             RuleFor(a => a.Ano)
                 .NotEmpty()
                 .WithMessage("O ano precisa ser informado");
-            RuleFor(a => a.Turno)
-                .NotEmpty()
-                .WithMessage("O turno precisa ser informado");
         }
     }
 }


### PR DESCRIPTION
25447  - Retirada a validação de turno pois alguns casos não é necessário passar, como é o caso do EJA.
[AB#25447](https://dev.azure.com/amcomgov/c1dcf343-60ee-40b6-a30a-3b9c12c6d220/_workitems/edit/25447)