### PR TITLE
Bug: 25973

### DIFF
--- a/src/SME.SGP.WebClient/src/paginas/CalendarioEscolar/CalendarioProfessor/index.js
+++ b/src/SME.SGP.WebClient/src/paginas/CalendarioEscolar/CalendarioProfessor/index.js
@@ -106,7 +106,8 @@ function CalendarioProfessor() {
             numeroMes: dia.getMonth() + 1,
             tipoCalendarioId,
             dre: turmaSelecionada.dre,
-            ue: turmaSelecionada.unidadeEscolar,
+            dreId: turmaSelecionada.dreId,
+            ue: turmaSelecionada.unidadeEscolar,            
             turma: turmaSelecionada.turma,
             anoLetivo: turmaSelecionada.anoLetivo,
           });


### PR DESCRIPTION
Ajuste na página de calendário de professor, onde ocorria erro ao clicar no dia do mês retornando que não foi possível buscar dados.