### PR TITLE
Fix/28436 r2

### DIFF
--- a/src/SME.SGP.WebClient/src/paginas/Relatorios/DiarioClasse/BoletimSimples/componentes/Filtro/componentes/AnoLetivoDropDown.js
+++ b/src/SME.SGP.WebClient/src/paginas/Relatorios/DiarioClasse/BoletimSimples/componentes/Filtro/componentes/AnoLetivoDropDown.js
@@ -1,5 +1,7 @@
-import React, { useEffect } from 'react';
+import React, { useCallback,useEffect,useState } from 'react';
 import PropTypes from 'prop-types';
+
+import FiltroHelper from '~componentes-sgp/filtro/helper';
 
 // Redux
 import { useSelector } from 'react-redux';
@@ -7,8 +9,29 @@ import { useSelector } from 'react-redux';
 // Componentes
 import { SelectComponent } from '~/componentes';
 
-function AnoLetivoDropDown({ form, onChange }) {
+function AnoLetivoDropDown({ form, onChange, consideraHistorico }) {
+
   const anosLetivos = useSelector(store => store.filtro.anosLetivos);
+  const [listaAnosLetivo, setListaAnosLetivo] = useState([]);  
+
+  const obterAnosLetivos = useCallback(async () => {    
+    let anosLetivo = [];
+
+    const anosLetivoComHistorico = await FiltroHelper.obterAnosLetivos({
+      consideraHistorico: true,
+    });
+    const anosLetivoSemHistorico = await FiltroHelper.obterAnosLetivos({
+      consideraHistorico: false,
+    });
+
+    anosLetivo = anosLetivoComHistorico.concat(anosLetivoSemHistorico);
+    
+    setListaAnosLetivo(anosLetivo);           
+  }, []);
+
+  useEffect(() => {
+    obterAnosLetivos();
+  }, [obterAnosLetivos]);
 
   useEffect(() => {
     if (anosLetivos.length === 1) {
@@ -24,10 +47,10 @@ function AnoLetivoDropDown({ form, onChange }) {
       valueText="desc"
       form={form}
       name="anoLetivo"
-      lista={anosLetivos}
+      lista={consideraHistorico ? listaAnosLetivo : anosLetivos}
       placeholder="Ano Letivo"
       onChange={onChange}
-      disabled={anosLetivos && anosLetivos.length === 1}
+      disabled={anosLetivos && anosLetivos.length === 1 && !consideraHistorico}      
     />
   );
 }
@@ -43,6 +66,7 @@ AnoLetivoDropDown.propTypes = {
 AnoLetivoDropDown.defaultProps = {
   form: {},
   onChange: () => null,
+  consideraHistorico: false,
 };
 
 export default AnoLetivoDropDown;

--- a/src/SME.SGP.WebClient/src/paginas/Relatorios/DiarioClasse/BoletimSimples/componentes/Filtro/index.js
+++ b/src/SME.SGP.WebClient/src/paginas/Relatorios/DiarioClasse/BoletimSimples/componentes/Filtro/index.js
@@ -157,12 +157,13 @@ function Filtro({ onFiltrar, resetForm }) {
       validateOnChange
     >
       {form => (
-        <Form className="col-md-12 mb-4">
+        <Form className="col-md-12 mb-4">          
           <Linha className="row mb-2">
             <Grid cols={2}>
               <AnoLetivoDropDown
                 form={form}
                 onChange={ano => setAnoLetivo(ano)}
+                consideraHistorico={true}
               />
             </Grid>
             <Grid


### PR DESCRIPTION
[AB#28436](https://dev.azure.com/amcomgov/c1dcf343-60ee-40b6-a30a-3b9c12c6d220/_workitems/edit/28436)
Correção filtro ano não permitia selecionar anos anteriores na tela de impressão do boletim (Fechamento > Boletim).