### PR TITLE
30409 - Obter usuário por Login ao invés de RF

### DIFF
--- a/src/SME.SGP.Dominio.Servicos/ServicoWorkflowAprovacao.cs
+++ b/src/SME.SGP.Dominio.Servicos/ServicoWorkflowAprovacao.cs
@@ -11,6 +11,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using SME.SGP.Infra.Interfaces;
+using Sentry;
 
 namespace SME.SGP.Dominio.Servicos
 {
@@ -326,7 +327,16 @@ namespace SME.SGP.Dominio.Servicos
                 var funcionariosRetorno = servicoNotificacao.ObterFuncionariosPorNivel(nivel.Workflow.UeId, nivel.Cargo);
 
                 foreach (var funcionario in funcionariosRetorno)
-                    usuarios.Add(servicoUsuario.ObterUsuarioPorCodigoRfLoginOuAdiciona(funcionario.Id));
+                {
+                    try
+                    {
+                        usuarios.Add(servicoUsuario.ObterUsuarioPorCodigoRfLoginOuAdiciona(string.Empty, funcionario.Id, buscaLogin: true));
+                    }
+                    catch (Exception e)
+                    {
+                        SentrySdk.CaptureException(e);
+                    }
+                }
             }
 
             foreach (var usuario in usuarios)


### PR DESCRIPTION
Vários usuários na base sem RF mas com Login, na hora de inserir da erro de Login já existente.

[AB#30409](https://dev.azure.com/amcomgov/c1dcf343-60ee-40b6-a30a-3b9c12c6d220/_workitems/edit/30409)