### PR TITLE
34728 - limpar dados da listagem quando o retorno é vazio

### DIFF
--- a/src/SME.SGP.WebClient/public/configuracoes/variaveis.json
+++ b/src/SME.SGP.WebClient/public/configuracoes/variaveis.json
@@ -1,5 +1,5 @@
 {
-  "API_URL": "https://localhost:5001/api",
+  "API_URL": "https://dev-novosgp.sme.prefeitura.sp.gov.br/api",
   "TRACKING_ID": "",
   "URL_SONDAGEM": "http://localhost:61540"
 }

--- a/src/SME.SGP.WebClient/src/componentes/listaPaginada/listaPaginada.js
+++ b/src/SME.SGP.WebClient/src/componentes/listaPaginada/listaPaginada.js
@@ -108,6 +108,7 @@ const ListaPaginada = props => {
         },
       })
       .then(resposta => {
+        setLinhas([]);
         setTotal(resposta.data.totalRegistros);
         setLinhas([...resposta.data.items]);
         if (setLista) {


### PR DESCRIPTION
[AB#34728](https://dev.azure.com/amcomgov/c1dcf343-60ee-40b6-a30a-3b9c12c6d220/_workitems/edit/34728)