### PR TITLE
R2 - Fix/27588

### DIFF
--- a/src/SME.SGP.WebClient/src/paginas/Gestao/AtribuicaoEsporadica/Form/index.js
+++ b/src/SME.SGP.WebClient/src/paginas/Gestao/AtribuicaoEsporadica/Form/index.js
@@ -61,6 +61,9 @@ function AtribuicaoEsporadicaForm({ match }) {
   const anoAtual = window.moment().format('YYYY');
   const [ehInfantil, setEhInfantil] = useState(false);
 
+  const [listaDres, setListaDres] = useState([]);
+  const [listaUes, setListaUes] = useState([]);
+
   const [valoresIniciais, setValoresIniciais] = useState({
     professorRf: '',
     professorNome: '',
@@ -143,7 +146,17 @@ function AtribuicaoEsporadicaForm({ match }) {
       'Deseja realmente cancelar as alterações?'
     );
     if (confirmou) {
-      form.resetForm();
+      if (listaDres?.length > 1) {
+        form.setFieldValue('dreId', valoresIniciais?.dreId);
+      }
+      if (listaUes?.length > 1) {
+        form.setFieldValue('ueId', valoresIniciais?.ueId);
+      }
+      form.setFieldValue('professorRf', valoresIniciais?.professorRf);
+      form.setFieldValue('professorNome', valoresIniciais?.professorNome);
+      form.setFieldValue('dataInicio', valoresIniciais?.dataInicio);
+      form.setFieldValue('dataFim', valoresIniciais?.dataFim);
+      form.setFieldValue('anoLetivo', valoresIniciais?.anoLetivo);
       setModoEdicao(false);
     }
   };
@@ -269,7 +282,10 @@ function AtribuicaoEsporadicaForm({ match }) {
                     <DreDropDown
                       label="Diretoria Regional de Educação (DRE)"
                       form={form}
-                      onChange={valor => setDreId(valor)}
+                      onChange={(valor, lista) => {
+                        setDreId(valor);
+                        setListaDres(lista);
+                      }}
                       desabilitado={somenteConsulta}
                     />
                   </Grid>
@@ -278,8 +294,9 @@ function AtribuicaoEsporadicaForm({ match }) {
                       label="Unidade Escolar (UE)"
                       dreId={dreId}
                       form={form}
-                      onChange={(v, infantil) => {
+                      onChange={(v, infantil, lista) => {
                         setEhInfantil(infantil);
+                        setListaUes(lista);
                       }}
                       desabilitado={somenteConsulta}
                     />

--- a/src/SME.SGP.WebClient/src/paginas/Gestao/AtribuicaoEsporadica/componentes/DreDropDown.js
+++ b/src/SME.SGP.WebClient/src/paginas/Gestao/AtribuicaoEsporadica/componentes/DreDropDown.js
@@ -35,14 +35,14 @@ function DreDropDown({ form, onChange, label, desabilitado }) {
   useEffect(() => {
     if (listaDres.length === 1) {
       form.setFieldValue('dreId', listaDres[0].valor);
-      onChange(listaDres[0].valor);
+      onChange(listaDres[0].valor, listaDres);
     }
   }, [listaDres]);
 
   useEffect(() => {
-    onChange();
+    onChange('', listaDres);
     if (!valorNuloOuVazio(form.values.dreId)) {
-      onChange(form.values.dreId);
+      onChange(form.values.dreId, listaDres);
     }
   }, [form.values.dreId]);
 
@@ -52,7 +52,9 @@ function DreDropDown({ form, onChange, label, desabilitado }) {
       form={form}
       name="dreId"
       className="fonte-14"
-      onChange={onChange}
+      onChange={valor => {
+        onChange(valor, listaDres);
+      }}
       lista={listaDres}
       valueOption="valor"
       containerVinculoId="containerFiltro"

--- a/src/SME.SGP.WebClient/src/paginas/Gestao/AtribuicaoEsporadica/componentes/UeDropDown.js
+++ b/src/SME.SGP.WebClient/src/paginas/Gestao/AtribuicaoEsporadica/componentes/UeDropDown.js
@@ -29,7 +29,7 @@ function UeDropDown({ form, onChange, dreId, label, desabilitado }) {
       setListaUes(lista);
       if (lista.length === 1) {
         form.setFieldValue('ueId', lista[0].valor);
-        onChange(lista[0].valor, lista[0].ehInfantil);
+        onChange(lista[0].valor, lista[0].ehInfantil, listaUes);
       }
     }
   }
@@ -39,6 +39,7 @@ function UeDropDown({ form, onChange, dreId, label, desabilitado }) {
       buscarUes();
     } else {
       setListaUes([]);
+      form.setFieldValue('ueId', undefined);
     }
   }, [dreId]);
 
@@ -49,7 +50,7 @@ function UeDropDown({ form, onChange, dreId, label, desabilitado }) {
       className="fonte-14"
       label={!label ? null : label}
       onChange={v => {
-        onChange(v, ehInfantil(v));
+        onChange(v, ehInfantil(v), listaUes);
       }}
       lista={listaUes}
       valueOption="valor"


### PR DESCRIPTION
Ao cancelar na tela de cadastro de atribuição esporádica os campos DRE e UE são limpos [AB#27588](https://dev.azure.com/amcomgov/c1dcf343-60ee-40b6-a30a-3b9c12c6d220/_workitems/edit/27588)