### PR TITLE
fix/35224

### DIFF
--- a/src/SME.SGP.Aplicacao/CasosDeUso/Aula/ObterAulaPorIdUseCase.cs
+++ b/src/SME.SGP.Aplicacao/CasosDeUso/Aula/ObterAulaPorIdUseCase.cs
@@ -30,11 +30,7 @@ namespace SME.SGP.Aplicacao
             if (turma == null)
                 throw new NegocioException($"Turma de codigo [{turmaCodigo}] não localizada!");
 
-            var bimestreAula = await mediator.Send(new ObterBimestreAtualQuery()
-            {
-                Turma = turma,
-                DataReferencia = dataAula
-            });
+            var bimestreAula = await mediator.Send(new ObterBimestreAtualQuery(dataAula, turma));
 
             var mesmoAnoLetivo = DateTime.Today.Year == dataAula.Year;
             return await mediator.Send(new TurmaEmPeriodoAbertoQuery(turma, DateTime.Today, bimestreAula, mesmoAnoLetivo));

--- a/src/SME.SGP.Aplicacao/CasosDeUso/CartaIntencoes/CartaIntencoesPersistenciaUseCase.cs
+++ b/src/SME.SGP.Aplicacao/CasosDeUso/CartaIntencoes/CartaIntencoesPersistenciaUseCase.cs
@@ -64,11 +64,7 @@ namespace SME.SGP.Aplicacao.CasosDeUso
             if (turma == null)
                 throw new NegocioException($"Turma de codigo [{turmaCodigo}] não localizada!");
 
-            var bimestreAula = await mediator.Send(new ObterBimestreAtualQuery()
-            {
-                Turma = turma,
-                DataReferencia = dataAula
-            });
+            var bimestreAula = await mediator.Send(new ObterBimestreAtualQuery(dataAula,turma));
 
             var mesmoAnoLetivo = DateTime.Today.Year == dataAula.Year;
             return await mediator.Send(new TurmaEmPeriodoAbertoQuery(turma, DateTime.Today, bimestreAula, mesmoAnoLetivo));

--- a/src/SME.SGP.Aplicacao/CasosDeUso/Devolutiva/AlterarDevolutivaUseCase.cs
+++ b/src/SME.SGP.Aplicacao/CasosDeUso/Devolutiva/AlterarDevolutivaUseCase.cs
@@ -22,7 +22,7 @@ namespace SME.SGP.Aplicacao
                 throw new NegocioException("Devolutiva informada não existe");
 
             var turma = await ObterTurma(param.TurmaCodigo);
-            var bimestre = await mediator.Send(new ObterBimestreAtualQuery(turma.CodigoTurma, DateTime.Today, turma));
+            var bimestre = await mediator.Send(new ObterBimestreAtualQuery(DateTime.Today, turma));
             await ValidarBimestreEmAberto(turma, bimestre);
 
             devolutiva.Descricao = param.Descricao;

--- a/src/SME.SGP.Aplicacao/CasosDeUso/Devolutiva/InserirDevolutivaUseCase.cs
+++ b/src/SME.SGP.Aplicacao/CasosDeUso/Devolutiva/InserirDevolutivaUseCase.cs
@@ -59,8 +59,8 @@ namespace SME.SGP.Aplicacao
 
         private async Task<int> ValidarBimestreDiarios(Turma turma, DateTime inicioEfetivo, DateTime fimEfetivo)
         {
-            var bimestreInicio = await mediator.Send(new ObterBimestreAtualQuery(turma.CodigoTurma, inicioEfetivo, turma));
-            var bimestreFim = await mediator.Send(new ObterBimestreAtualQuery(turma.CodigoTurma, fimEfetivo, turma));
+            var bimestreInicio = await mediator.Send(new ObterBimestreAtualQuery(inicioEfetivo, turma));
+            var bimestreFim = await mediator.Send(new ObterBimestreAtualQuery(fimEfetivo, turma));
 
             if (bimestreInicio != bimestreFim)
             {

--- a/src/SME.SGP.Aplicacao/CasosDeUso/DiarioBordo/ObterDiarioBordoUseCase.cs
+++ b/src/SME.SGP.Aplicacao/CasosDeUso/DiarioBordo/ObterDiarioBordoUseCase.cs
@@ -47,11 +47,7 @@ namespace SME.SGP.Aplicacao
             if (turma == null)
                 throw new NegocioException($"Turma de codigo [{turmaCodigo}] não localizada!");
 
-            var bimestreAula = await mediator.Send(new ObterBimestreAtualQuery()
-            {
-                Turma = turma,
-                DataReferencia = dataAula
-            });
+            var bimestreAula = await mediator.Send(new ObterBimestreAtualQuery(dataAula, turma));
 
             var mesmoAnoLetivo = DateTime.Today.Year == dataAula.Year;
             return await mediator.Send(new TurmaEmPeriodoAbertoQuery(turma, DateTime.Today, bimestreAula, mesmoAnoLetivo));

--- a/src/SME.SGP.Aplicacao/CasosDeUso/RelatoriosPAP/ObterListaSemestresUseCase.cs
+++ b/src/SME.SGP.Aplicacao/CasosDeUso/RelatoriosPAP/ObterListaSemestresUseCase.cs
@@ -1,4 +1,5 @@
 ﻿using MediatR;
+using SME.SGP.Dominio;
 using SME.SGP.Infra;
 using System;
 using System.Collections.Generic;
@@ -10,7 +11,11 @@ namespace SME.SGP.Aplicacao
     {
         public static async Task<List<SemestreAcompanhamentoDto>> Executar(IMediator mediator, string turmaCodigo)
         {
-            var bimestreAtual = await mediator.Send(new ObterBimestreAtualQuery(turmaCodigo, DateTime.Today));
+            var turma = await mediator.Send(new ObterTurmaPorCodigoQuery(turmaCodigo));
+            if (turma == null)
+                throw new NegocioException("A turma informada não foi encontrada!");
+
+            var bimestreAtual = await mediator.Send(new ObterBimestreAtualQuery(DateTime.Today, turma));
 
             return await mediator.Send(new ObterListaSemestresRelatorioPAPQuery(bimestreAtual));
         }

--- a/src/SME.SGP.Aplicacao/Queries/PeriodoEscolar/ObterBimestreAtualPorTurmaQuery/ObterBimestreAtualQuery.cs
+++ b/src/SME.SGP.Aplicacao/Queries/PeriodoEscolar/ObterBimestreAtualPorTurmaQuery/ObterBimestreAtualQuery.cs
@@ -6,22 +6,13 @@ namespace SME.SGP.Aplicacao
 {
     public class ObterBimestreAtualQuery : IRequest<int>
     {
-        public ObterBimestreAtualQuery() { }
-
-        public ObterBimestreAtualQuery(string turmaCodigo, DateTime dataReferencia, Turma turma = null)
+        public ObterBimestreAtualQuery(DateTime dataReferencia, Turma turma = null)
         {
-            if (string.IsNullOrEmpty(turmaCodigo))
-                throw new NegocioException("Para obter o bimestre atual é necessário informar o código da turma");
-            if (dataReferencia == DateTime.MinValue)
-                throw new NegocioException("Para obter o bimestre atual é necessário informar a data de referência");
-
-            TurmaCodigo = turmaCodigo;
             DataReferencia = dataReferencia;
             Turma = turma;
         }
 
         public Turma Turma { get; set; }
-        public string TurmaCodigo { get; set; }
         public DateTime DataReferencia { get; set; }
     }
 }

--- a/src/SME.SGP.Aplicacao/Queries/PeriodoEscolar/ObterBimestreAtualPorTurmaQuery/ObterBimestreAtualQueryHandler.cs
+++ b/src/SME.SGP.Aplicacao/Queries/PeriodoEscolar/ObterBimestreAtualPorTurmaQuery/ObterBimestreAtualQueryHandler.cs
@@ -10,12 +10,10 @@ namespace SME.SGP.Aplicacao
     public class ObterBimestreAtualQueryHandler : IRequestHandler<ObterBimestreAtualQuery, int>
     {
         private readonly IRepositorioPeriodoEscolar repositorioPeriodoEscolar;
-        private readonly IRepositorioTurma repositorioTurma;
 
-        public ObterBimestreAtualQueryHandler(IRepositorioPeriodoEscolar repositorioPeriodoEscolar, IRepositorioTurma repositorioTurma)
+        public ObterBimestreAtualQueryHandler(IRepositorioPeriodoEscolar repositorioPeriodoEscolar)
         {
             this.repositorioPeriodoEscolar = repositorioPeriodoEscolar ?? throw new ArgumentNullException(nameof(repositorioPeriodoEscolar));
-            this.repositorioTurma = repositorioTurma ?? throw new ArgumentNullException(nameof(repositorioTurma));
         }
         public async Task<int> Handle(ObterBimestreAtualQuery request, CancellationToken cancellationToken)
         {

--- a/src/SME.SGP.Aplicacao/Queries/PeriodoEscolar/ObterBimestreAtualPorTurmaQuery/ObterBimestreAtualQueryValidator.cs
+++ b/src/SME.SGP.Aplicacao/Queries/PeriodoEscolar/ObterBimestreAtualPorTurmaQuery/ObterBimestreAtualQueryValidator.cs
@@ -1,0 +1,20 @@
+﻿using FluentValidation;
+using MediatR;
+using SME.SGP.Dominio;
+using System;
+
+namespace SME.SGP.Aplicacao
+{
+    public class ObterBimestreAtualQueryValidator : AbstractValidator<ObterBimestreAtualQuery>
+    {
+        public ObterBimestreAtualQueryValidator()
+        {
+            RuleFor(c => c.Turma)
+                .NotNull()
+                .WithMessage("Para obter o bimestre atual é necessário informar a turma.");
+            RuleFor(c => c.DataReferencia)
+                .Must(a => a > DateTime.MinValue)
+                .WithMessage("Para obter o bimestre atual é necessário informar a data de referência.");
+        }
+    }
+}


### PR DESCRIPTION
[AB#35224](https://dev.azure.com/amcomgov/c1dcf343-60ee-40b6-a30a-3b9c12c6d220/_workitems/edit/35224) 
Refatorado o modo como estava obtendo a turma, pois estava enviando tanto a entidade turma como o turma código. Foi alterado para enviar somente turma e adicionado um validator