### PR TITLE
Bug: 48257

### DIFF
--- a/src/SME.SGP.Aplicacao/Queries/ComponentesCurriculares/ObterComponentesCurricularesPorTurmasCodigo/ObterComponentesCurricularesPorTurmasCodigoQueryHandler.cs
+++ b/src/SME.SGP.Aplicacao/Queries/ComponentesCurriculares/ObterComponentesCurricularesPorTurmasCodigo/ObterComponentesCurricularesPorTurmasCodigoQueryHandler.cs
@@ -101,7 +101,9 @@ namespace SME.SGP.Aplicacao
 
                 foreach (var disciplina in disciplinas)
                 {
-                    if (!retorno.Any(d => d.CodigoComponenteCurricular == disciplina.CodigoComponenteCurricular))
+                    var jaAdicionadaPorTurma = retorno.Any(d => d.TurmaCodigo.Equals(disciplina.TurmaCodigo) &&
+                                                                d.CodigoComponenteCurricular == disciplina.CodigoComponenteCurricular);
+                    if (!jaAdicionadaPorTurma)
                         retorno.Add(MapearParaDto(disciplina, disciplinasComObjetivos, turmaEspecial));
                 }
             }


### PR DESCRIPTION
Ajuste na funcionalidade de tratar disciplinas da turma retornadas pelo EOL para considerar também as turmas e não somente o código da disciplina. Dessa forma teremos a informação correta para a turma original.