### PR TITLE
51912 - excluir as imagens nas seção Percurso individual da criança

### DIFF
--- a/src/SME.SGP.Aplicacao/CasosDeUso/AcompanhamentoTurma/SalvarAcompanhamentoTurmaUseCase.cs
+++ b/src/SME.SGP.Aplicacao/CasosDeUso/AcompanhamentoTurma/SalvarAcompanhamentoTurmaUseCase.cs
@@ -32,21 +32,21 @@ namespace SME.SGP.Aplicacao
         private async Task<AcompanhamentoTurma> AtualizaApanhadoTurma(AcompanhamentoTurmaDto dto)
         {
             var acompanhamento = await ObterAcompanhamentoTurmaPorId(dto.AcompanhamentoTurmaId);
-            MoverRemoverExcluidos(dto, acompanhamento);
+            await MoverRemoverExcluidos(dto, acompanhamento);
             acompanhamento.ApanhadoGeral = dto.ApanhadoGeral;
             return await mediator.Send(new SalvarAcompanhamentoTurmaCommand(acompanhamento));
         }
 
-        private void MoverRemoverExcluidos(AcompanhamentoTurmaDto dto, AcompanhamentoTurma acompanhamento)
+        private async Task MoverRemoverExcluidos(AcompanhamentoTurmaDto dto, AcompanhamentoTurma acompanhamento)
         {
             if (!string.IsNullOrEmpty(dto.ApanhadoGeral))
             {
-                var moverArquivo = mediator.Send(new MoverArquivosTemporariosCommand(TipoArquivo.AcompanhamentoAluno, acompanhamento.ApanhadoGeral, dto.ApanhadoGeral));
-                dto.ApanhadoGeral = moverArquivo.Result;
+                var moverArquivo = await mediator.Send(new MoverArquivosTemporariosCommand(TipoArquivo.AcompanhamentoAluno, acompanhamento.ApanhadoGeral, dto.ApanhadoGeral));
+                dto.ApanhadoGeral = moverArquivo;
             }
             if (!string.IsNullOrEmpty(acompanhamento.ApanhadoGeral))
             {
-                var deletarArquivosNaoUtilziados = mediator.Send(new RemoverArquivosExcluidosCommand(acompanhamento.ApanhadoGeral, dto.ApanhadoGeral, TipoArquivo.AcompanhamentoAluno.Name()));
+                await mediator.Send(new RemoverArquivosExcluidosCommand(acompanhamento.ApanhadoGeral, dto.ApanhadoGeral, TipoArquivo.AcompanhamentoAluno.Name()));
             }
         }
 

--- a/src/SME.SGP.Aplicacao/Commands/Armazenamento/DownloadArquivo/DownloadArquivoCommandHandler.cs
+++ b/src/SME.SGP.Aplicacao/Commands/Armazenamento/DownloadArquivo/DownloadArquivoCommandHandler.cs
@@ -17,22 +17,25 @@ namespace SME.SGP.Aplicacao
             var extencao = Path.GetExtension(request.Nome);
             var nomeArquivo = $"{request.Codigo}{extencao}";
             var caminhoArquivo = Path.Combine($"{caminhoBase}", nomeArquivo);
-
+            
             try
             {
+                if (!File.Exists(caminhoArquivo))
+                {
+                   var arq = Array.Empty<byte>();
+                    return Task.FromResult(arq);
+                }
                 var arquivo = File.ReadAllBytes(caminhoArquivo);
-
+            
                 if (arquivo != null)
-                    return Task.FromResult(arquivo);
-
-                throw new NegocioException("A imagem da criança/aluno não foi encontrada");
+                     arquivo = Array.Empty<byte>();
+                
+                return Task.FromResult(arquivo);
             }
             catch (Exception)
             {
                 throw new NegocioException("A imagem da criança/aluno não foi encontrada.");
             }
-         
-
         }
 
         private string ObterCaminhoArquivos(TipoArquivo tipo)


### PR DESCRIPTION
Excluir as imagens nas seção Percurso individual da criança ou Observações adicionais e remover a mensagem de foto da criança não encontrada
[AB#51912](https://dev.azure.com/amcomgov/c1dcf343-60ee-40b6-a30a-3b9c12c6d220/_workitems/edit/51912)
[AB#51961](https://dev.azure.com/amcomgov/c1dcf343-60ee-40b6-a30a-3b9c12c6d220/_workitems/edit/51961)