### PR TITLE
Bug: 53987

### DIFF
--- a/src/SME.SGP.Aplicacao/Consultas/ConsultasDisciplina.cs
+++ b/src/SME.SGP.Aplicacao/Consultas/ConsultasDisciplina.cs
@@ -216,13 +216,13 @@ namespace SME.SGP.Aplicacao
         public async Task<IEnumerable<DisciplinaResposta>> ObterComponentesRegencia(Turma turma, long componenteCurricularCodigo)
         {
             var usuario = await servicoUsuario.ObterUsuarioLogado();
-            var regencias = await mediator.Send(new ObterComponentesCurricularesRegenciaPorTurmaCodigoQuery(turma.CodigoTurma));
             
             if (usuario.EhProfessorCj())
                 return await ObterComponentesCJ(turma.ModalidadeCodigo, turma.CodigoTurma, turma.Ue.CodigoUe, componenteCurricularCodigo, usuario.CodigoRf);
             else
-            {
-                var componentesCurriculares = await servicoEOL.ObterComponentesRegenciaPorAno(turma.AnoTurmaInteiro);
+            {                
+                var componentesCurriculares = await servicoEOL
+                    .ObterComponentesRegenciaPorAno(turma.TipoTurno == 4 ? turma.AnoTurmaInteiro : 0);
 
                 return MapearComponentes(componentesCurriculares.OrderBy(c => c.Descricao));
             }


### PR DESCRIPTION
Ajuste ao obter notas do conselho de classe que acionar API/EOL para obter as disciplinas só será informado o ano se a turma for do tipo turno 4, senão será 0 para disciplinas padrões de regência.