### PR TITLE
Ajuste no endpoint de períodos + frequencia listão

### DIFF
--- a/src/SME.SGP.Aplicacao/CasosDeUso/PeriodosEscolares/ObterPeriodosPorComponenteUseCase.cs
+++ b/src/SME.SGP.Aplicacao/CasosDeUso/PeriodosEscolares/ObterPeriodosPorComponenteUseCase.cs
@@ -18,12 +18,14 @@ namespace SME.SGP.Aplicacao
         {
 
             var periodoEscolar = await mediator.Send(new ObterPeriodosEscolaresPorComponenteBimestreTurmaQuery(turmaCodigo, componenteCodigo, bimestre));
-
+            var dadosTurma = await mediator.Send(new ObterTurmaPorCodigoQuery(turmaCodigo));
+            var periodoBimestre = await mediator.Send(new ObterPeriodoEscolarPorTurmaBimestreQuery(dadosTurma, bimestre));
             var listaPeriodos = new List<PeriodoEscolarComponenteDto>();
 
-            if(periodoEscolar.Any())
-                listaPeriodos = ehRegencia ? SepararSemanasRegencia(periodoEscolar.FirstOrDefault().DataInicio, periodoEscolar.FirstOrDefault().DataFim, exibirDataFutura)
-                                       : SepararPeriodosAulas(periodoEscolar.OrderBy(x => x.DataAula), exibirDataFutura);
+            if (periodoEscolar.Any() && !ehRegencia)
+                listaPeriodos = SepararPeriodosAulas(periodoEscolar.OrderBy(x => x.DataAula), exibirDataFutura);
+            else
+                listaPeriodos = SepararSemanasRegencia(periodoBimestre.PeriodoInicio, periodoBimestre.PeriodoFim, exibirDataFutura);
 
             return listaPeriodos;
         }

--- a/src/SME.SGP.Aplicacao/CasosDeUso/PeriodosEscolares/ObterPeriodosPorComponenteUseCase.cs
+++ b/src/SME.SGP.Aplicacao/CasosDeUso/PeriodosEscolares/ObterPeriodosPorComponenteUseCase.cs
@@ -16,7 +16,6 @@ namespace SME.SGP.Aplicacao
 
         public async Task<IEnumerable<PeriodoEscolarComponenteDto>> Executar(string turmaCodigo, long componenteCodigo, bool ehRegencia, int bimestre, bool exibirDataFutura = false)
         {
-
             var periodoEscolar = await mediator.Send(new ObterPeriodosEscolaresPorComponenteBimestreTurmaQuery(turmaCodigo, componenteCodigo, bimestre));
             var dadosTurma = await mediator.Send(new ObterTurmaPorCodigoQuery(turmaCodigo));
             var periodoBimestre = await mediator.Send(new ObterPeriodoEscolarPorTurmaBimestreQuery(dadosTurma, bimestre));
@@ -24,7 +23,7 @@ namespace SME.SGP.Aplicacao
 
             if (periodoEscolar.Any() && !ehRegencia)
                 listaPeriodos = SepararPeriodosAulas(periodoEscolar.OrderBy(x => x.DataAula), exibirDataFutura);
-            else
+            else if(periodoBimestre != null)
                 listaPeriodos = SepararSemanasRegencia(periodoBimestre.PeriodoInicio, periodoBimestre.PeriodoFim, exibirDataFutura);
 
             return listaPeriodos;

--- a/src/SME.SGP.Aplicacao/Queries/Frequencia/ObterListaFrequenciaAulas/ObterListaFrequenciaAulasQueryHandler.cs
+++ b/src/SME.SGP.Aplicacao/Queries/Frequencia/ObterListaFrequenciaAulas/ObterListaFrequenciaAulasQueryHandler.cs
@@ -32,7 +32,7 @@ namespace SME.SGP.Aplicacao
             {
                 // Apos o bimestre da inatividade o aluno não aparece mais na lista de frequencia ou
                 // se a matrícula foi ativada após a data da aula                
-                if (aluno.EstaInativo(request.DataInicio) || 
+                if (aluno.EstaInativo(request.DataInicio) ||
                    (aluno.CodigoSituacaoMatricula == SituacaoMatriculaAluno.Ativo && aluno.DataMatricula > request.DataFim))
                     continue;
 
@@ -63,25 +63,28 @@ namespace SME.SGP.Aplicacao
                 // Indicativo de Frequencia (%)
                 registroFrequenciaAluno.IndicativoFrequencia = ObterIndicativoFrequencia(frequenciaAluno, request.PercentualAlerta, request.PercentualCritico, request.TurmaPossuiFrequenciaRegistrada);
 
-                if (RegistraFrequencia(request.RegistraFrequencia, request.Aulas, request.Turma))
+                if (request.Aulas.Any())
                 {
-                    var registrosFrequenciaAluno = request.RegistrosFrequenciaAlunos.Where(a => a.AlunoCodigo == aluno.CodigoAluno);
-                    var anotacoesAluno = request.AnotacoesTurma.Where(a => a.AlunoCodigo == aluno.CodigoAluno);
+                    if (RegistraFrequencia(request.RegistraFrequencia, request.Aulas, request.Turma))
+                    {
+                        var registrosFrequenciaAluno = request.RegistrosFrequenciaAlunos.Where(a => a.AlunoCodigo == aluno.CodigoAluno);
+                        var anotacoesAluno = request.AnotacoesTurma.Where(a => a.AlunoCodigo == aluno.CodigoAluno);
 
-                    registroFrequenciaAluno.CarregarAulas(request.Aulas, registrosFrequenciaAluno, aluno, anotacoesAluno, frequenciaPreDefinida);
+                        registroFrequenciaAluno.CarregarAulas(request.Aulas, registrosFrequenciaAluno, aluno, anotacoesAluno, frequenciaPreDefinida);
+                    }
+
+                    registrosFrequencias.Alunos.Add(registroFrequenciaAluno);
                 }
-
-                registrosFrequencias.Alunos.Add(registroFrequenciaAluno);
             }
 
-            return registrosFrequencias;
+            return registrosFrequencias.Aulas.Any() ? registrosFrequencias : null;
         }
 
         private bool RegistraFrequencia(bool registraFrequencia, IEnumerable<Aula> aulas, Turma turma)
         {
             var aula = aulas.First();
 
-            return registraFrequencia 
+            return registraFrequencia
                 && aula.PermiteRegistroFrequencia(turma);
         }
 


### PR DESCRIPTION
Foi ajustado o endpoint de períodos para o diário de bordo, pegando não pelas aulas e sim pelo início e término do bimestre, e reparei também que se por exemplo, na tela de frequências, aquele período selecionado não tiver aula, ele exibe erro interno. Foi feito um tratamento para que isso não acontecesse mais. Segue o teste feito em dev do erro: 
![image](https://user-images.githubusercontent.com/56418006/149555345-9547afc9-8575-46bc-9ea8-2e882f4b1984.png)
