### PR TITLE
56982 - Icone de avaliação cadastrada não aparece no calendário

### DIFF
--- a/src/SME.SGP.Aplicacao/Queries/TipoCalendario/ObterAulaEventoAvaliacaoCalendarioProfessorPorMes/ObterAulaEventoAvaliacaoCalendarioProfessorPorMesQueryHandler.cs
+++ b/src/SME.SGP.Aplicacao/Queries/TipoCalendario/ObterAulaEventoAvaliacaoCalendarioProfessorPorMes/ObterAulaEventoAvaliacaoCalendarioProfessorPorMesQueryHandler.cs
@@ -51,7 +51,6 @@ namespace SME.SGP.Aplicacao
                                                              from disciplina in avaliacao.Disciplinas
                                                              where componentesCurricularesDoDia.Contains(disciplina.DisciplinaId.ToString()) || avaliacao.ProfessorRf == request.UsuarioCodigoRf
                                                              where avaliacao.TipoAvaliacaoId != 18 
-                                                             where avaliacao.AtividadeClassroomId != null
                                                              select true);
 
                             if (temAvaliacaoComComponente.Any())


### PR DESCRIPTION
[AB#56982](https://dev.azure.com/amcomgov/c1dcf343-60ee-40b6-a30a-3b9c12c6d220/_workitems/edit/56982)