### PR TITLE
Removido a vinculação de boletim simples ao jasper (agora é razor)

### DIFF
--- a/src/SME.SGP.Dominio/Entidades/RelatorioCorrelacao.cs
+++ b/src/SME.SGP.Dominio/Entidades/RelatorioCorrelacao.cs
@@ -36,7 +36,7 @@ namespace SME.SGP.Dominio
         {
             return this.MemberwiseClone();
         }
-        public bool EhRelatorioJasper => TipoRelatorio.EhUmDosValores(TipoRelatorio.Boletim, TipoRelatorio.ConselhoClasseAluno, TipoRelatorio.ConselhoClasseTurma, TipoRelatorio.HistoricoEscolarFundamental);
+        public bool EhRelatorioJasper => TipoRelatorio.EhUmDosValores(TipoRelatorio.ConselhoClasseAluno, TipoRelatorio.ConselhoClasseTurma, TipoRelatorio.HistoricoEscolarFundamental);
 
         public bool PrazoDownloadExpirado => (DateTime.Now - CriadoEm).Days > 1;
     }


### PR DESCRIPTION
Removido a vinculação de boletim simples ao jasper (agora é razor)