### PR TITLE
Bug: 62006

### DIFF
--- a/src/SME.SGP.Api/Controllers/AbrangenciaController.cs
+++ b/src/SME.SGP.Api/Controllers/AbrangenciaController.cs
@@ -141,6 +141,12 @@ namespace SME.SGP.Api.Controllers
             var retorno = await consultasAbrangencia
                 .ObterSemestres(filtroSemestreDto.Modalidade, ConsideraHistorico, filtroSemestreDto.AnoLetivo, filtroSemestreDto.DreCodigo, filtroSemestreDto.UeCodigo);
 
+            if ((retorno == null || !retorno.Any()) && !ConsideraHistorico)
+            {
+                retorno = await consultasAbrangencia
+                    .ObterSemestres(filtroSemestreDto.Modalidade, true, filtroSemestreDto.AnoLetivo, filtroSemestreDto.DreCodigo, filtroSemestreDto.UeCodigo);
+            }
+
             if (!retorno.Any())
                 return NoContent();
 
@@ -157,7 +163,7 @@ namespace SME.SGP.Api.Controllers
             IEnumerable<AbrangenciaTurmaRetorno> turmas;
             turmas = await consultasAbrangencia.ObterTurmas(codigoUe, modalidade, periodo, ConsideraHistorico, anoLetivo, tipos, consideraNovosAnosInfantil);
             
-            if(turmas == null && !turmas.Any() && !ConsideraHistorico)
+            if((turmas == null || !turmas.Any()) && !ConsideraHistorico)
                 turmas = await consultasAbrangencia.ObterTurmas(codigoUe, modalidade, periodo, true, anoLetivo, tipos, consideraNovosAnosInfantil);
 
             if (!turmas.Any())


### PR DESCRIPTION
Ajuste na listagem e abrangência de turma para o filtro de relatório de frequência para turmas ajustando a condição de verificação de itens na lista.
Aplicação desse ajuste na listagem de semestre, caso não retorne itens na lista sem considerar histórico, faz a busca novamente como histórico.