### PR TITLE
Atribuição de CJ - Não é possível realizar substituição na turma onde o professor já é o titular.

### DIFF
--- a/src/SME.SGP.Aplicacao/Commands/AtribuicaoCJ/InserirAtribuicaoCJ/InserirAtribuicaoCJCommandHandler.cs
+++ b/src/SME.SGP.Aplicacao/Commands/AtribuicaoCJ/InserirAtribuicaoCJ/InserirAtribuicaoCJCommandHandler.cs
@@ -39,8 +39,8 @@ namespace SME.SGP.Aplicacao
 
             await ValidaComponentesCurricularesQueNaoPodemSerSubstituidos(atribuicaoCJ);
 
-            if (request.ProfessoresTitulares != null && request.ProfessoresTitulares.Any(c => c.ProfessorRf.Contains(atribuicaoCJ.ProfessorRf) && c.DisciplinaId == atribuicaoCJ.DisciplinaId))
-                throw new NegocioException("Não é possível realizar substituição na turma onde o professor já é o titular.");
+            //if (request.ProfessoresTitulares != null && request.ProfessoresTitulares.Any(c => c.ProfessorRf.Contains(atribuicaoCJ.ProfessorRf) && c.DisciplinaId == atribuicaoCJ.DisciplinaId))
+            //    throw new NegocioException("Não é possível realizar substituição na turma onde o professor já é o titular.");
 
             if (request.AtribuicoesAtuais == null)
                 request.AtribuicoesAtuais = await repositorioAtribuicaoCJ.ObterPorFiltros(atribuicaoCJ.Modalidade, atribuicaoCJ.TurmaId,


### PR DESCRIPTION
Realizamos a correção comentando a validação atribuída, pois a mesma não será necessária.