### PR TITLE
Alterar consulta de Frequencia Registrada para Aula

### DIFF
--- a/src/SME.SGP.Aplicacao/Queries/Aula/ObterDatasAulasPorProfessorEComponente/ObterDatasAulasPorProfessorEComponenteQueryHandler.cs
+++ b/src/SME.SGP.Aplicacao/Queries/Aula/ObterDatasAulasPorProfessorEComponente/ObterDatasAulasPorProfessorEComponenteQueryHandler.cs
@@ -32,7 +32,7 @@ namespace SME.SGP.Aplicacao
             var periodosEscolares = await ObterPeriodosEscolares(tipoCalendarioId);
             var usuarioLogado = await mediator.Send(new ObterUsuarioLogadoQuery());
 
-            var datasAulas = ObterAulasNosPeriodos(periodosEscolares, turma.AnoLetivo, turma.CodigoTurma, request.ComponenteCurricularCodigo,string.Empty);
+            var datasAulas = await ObterAulasNosPeriodos(periodosEscolares, turma.AnoLetivo, turma.CodigoTurma, request.ComponenteCurricularCodigo,string.Empty);
 
             if (datasAulas == null || !datasAulas.Any())
                 return default;
@@ -68,7 +68,7 @@ namespace SME.SGP.Aplicacao
                         || usuarioLogado.EhProfessorPoed()) || usuarioLogado.EhProfessorPap() || usuarioLogado.EhProfessorPaee()),
                         ProfessorRf = a.ProfessorRf,
                         CriadoPor = a.CriadoPor,
-                        PossuiFrequenciaRegistrada = await mediator.Send(new ObterAulaPossuiFrequenciaQuery(a.IdAula)),
+                        PossuiFrequenciaRegistrada = a.PossuiFrequenciaRegistrada,
                         TipoAula = a.TipoAula
                     }).DistinctBy(a => a.Result.AulaId).Select(a => a.Result)
                 });
@@ -109,25 +109,26 @@ namespace SME.SGP.Aplicacao
             return turma;
         }
 
-        private IEnumerable<DataAulasProfessorDto> ObterAulasNosPeriodos(IEnumerable<PeriodoEscolar> periodosEscolares, int anoLetivo, string turmaCodigo, string componenteCurricularCodigo, string professorRf)
+        private async Task<IEnumerable<DataAulasProfessorDto>> ObterAulasNosPeriodos(IEnumerable<PeriodoEscolar> periodosEscolares, int anoLetivo, string turmaCodigo, string componenteCurricularCodigo, string professorRf)
         {
-            var aulas = repositorioConsulta.ObterDatasDeAulasPorAnoTurmaEDisciplina(periodosEscolares.Select(s => s.Id).Distinct(), anoLetivo, turmaCodigo, componenteCurricularCodigo, professorRf, null, null,false);
+            var listaDataAulas = new List<DataAulasProfessorDto>();
+            var aulas = await repositorioConsulta.ObterDatasDeAulasPorAnoTurmaEDisciplinaVerificandoSePossuiFrequenciaAulaRegistrada(periodosEscolares.Select(s => s.Id).Distinct(), anoLetivo, turmaCodigo, componenteCurricularCodigo, professorRf, null, null,false);
             foreach (var periodoEscolar in periodosEscolares)
             {
-                foreach (var aula in aulas)
+                listaDataAulas.AddRange(aulas.Select(aula => new DataAulasProfessorDto
                 {
-                    yield return new DataAulasProfessorDto
-                    {
-                        Data = aula.DataAula,
-                        IdAula = aula.Id,
-                        AulaCJ = aula.AulaCJ,
-                        Bimestre = periodoEscolar.Bimestre,
-                        ProfessorRf = aula.ProfessorRf,
-                        CriadoPor = aula.CriadoPor,
-                        TipoAula = aula.TipoAula
-                    };
-                }
+                    Data = aula.DataAula,
+                    IdAula = aula.Id,
+                    AulaCJ = aula.AulaCJ,
+                    Bimestre = periodoEscolar.Bimestre,
+                    ProfessorRf = aula.ProfessorRf,
+                    CriadoPor = aula.CriadoPor,
+                    TipoAula = aula.TipoAula,
+                    PossuiFrequenciaRegistrada = aula.PossuiFrequenciaRegistrada
+                }));
             }
+
+            return listaDataAulas;
         }
 
     }

--- a/src/SME.SGP.Dados/Repositorios/RepositorioAulaConsulta.cs
+++ b/src/SME.SGP.Dados/Repositorios/RepositorioAulaConsulta.cs
@@ -621,6 +621,7 @@ namespace SME.SGP.Dados.Repositorios
             query.AppendLine("inner join periodo_escolar pe on pe.id = ANY(@periodoEscolarId) ");
             query.AppendLine("                and pe.periodo_inicio <= a.data_aula ");
             query.AppendLine("                and pe.periodo_fim >= a.data_aula ");
+            query.AppendLine(" LEFT JOIN registro_frequencia rf ON rf.aula_id = a.id ");
             query.AppendLine("where");
             query.AppendLine("not a.excluido");
             query.AppendLine("and a.turma_id = @turmaCodigo ");

--- a/src/SME.SGP.Dados/Repositorios/RepositorioAulaConsulta.cs
+++ b/src/SME.SGP.Dados/Repositorios/RepositorioAulaConsulta.cs
@@ -604,6 +604,50 @@ namespace SME.SGP.Dados.Repositorios
             });
         }
 
+        public async Task<IEnumerable<AulaPossuiFrequenciaAulaRegistradaDto>> ObterDatasDeAulasPorAnoTurmaEDisciplinaVerificandoSePossuiFrequenciaAulaRegistrada(IEnumerable<long> periodosEscolaresId, int anoLetivo, string turmaCodigo, 
+            string disciplinaId, string usuarioRF, DateTime? aulaInicio, DateTime? aulaFim, bool aulaCj)
+        {
+            var query = new StringBuilder(@"SELECT DISTINCT a.id,
+                                            a.data_aula AS DataAula,
+                                                a.aula_cj AS AulaCJ, 
+                                                a.professor_rf AS ProfessorRf,
+                                                a.criado_por AS CriadoPor, 
+                                                a.tipo_aula AS TipoAula,
+                                                CASE WHEN rf.id > 0 THEN TRUE ELSE false
+                                            END PossuiFrequenciaRegistrada ");
+            query.AppendLine("from aula a ");
+            query.AppendLine("inner join turma t on ");
+            query.AppendLine("a.turma_id = t.turma_id ");
+            query.AppendLine("inner join periodo_escolar pe on pe.id = ANY(@periodoEscolarId) ");
+            query.AppendLine("                and pe.periodo_inicio <= a.data_aula ");
+            query.AppendLine("                and pe.periodo_fim >= a.data_aula ");
+            query.AppendLine("where");
+            query.AppendLine("not a.excluido");
+            query.AppendLine("and a.turma_id = @turmaCodigo ");
+            query.AppendLine("and a.disciplina_id = @disciplinaId ");
+            query.AppendLine("and t.ano_letivo = @anoLetivo ");
+
+            if (aulaInicio.HasValue && aulaFim.HasValue)
+                query.AppendLine("and a.data_aula between @aulaInicio and @aulaFim ");
+
+            if (!string.IsNullOrWhiteSpace(usuarioRF))
+                query.AppendLine("and a.professor_rf = @usuarioRF ");
+
+            if (aulaCj)
+                query.AppendLine("and a.aula_cj = true");
+
+            var parametros = new
+            {
+                periodoEscolarId = periodosEscolaresId.Select(c => c).ToArray(),
+                usuarioRF,
+                anoLetivo,
+                turmaCodigo,
+                disciplinaId,
+                aulaInicio,
+                aulaFim
+            };
+            return await database.Conexao.QueryAsync<AulaPossuiFrequenciaAulaRegistradaDto>(query.ToString(), parametros);
+        }
         public IEnumerable<Aula> ObterDatasDeAulasPorAnoTurmaEDisciplina(IEnumerable<long> periodosEscolaresId, int anoLetivo, string turmaCodigo, string disciplinaId, string usuarioRF, DateTime? aulaInicio, DateTime? aulaFim, bool aulaCj)
         {
             var query = new StringBuilder("select distinct a.*, t.* ");

--- a/src/SME.SGP.Dominio.Interfaces/Repositorios/IRepositorioAulaConsulta.cs
+++ b/src/SME.SGP.Dominio.Interfaces/Repositorios/IRepositorioAulaConsulta.cs
@@ -100,5 +100,8 @@ namespace SME.SGP.Dominio.Interfaces
         Task<IEnumerable<DiarioBordoPorPeriodoDto>> ObterDatasAulaDiarioBordoPorPeriodo(string turmaCodigo, long componenteCurricularId, DateTime dataInicio, DateTime dataFim);
         Task<IEnumerable<DiarioBordoPorPeriodoDto>> ObterAulasDiariosPorPeriodo(string turmaCodigo, string componenteCurricularFilhoCodigo, string componenteCurricularPaiCodigo, DateTime dataFim, DateTime dataInicio);
         Task<IEnumerable<TotalAulasNaoLancamNotaDto>> ObterTotalAulasPorTurmaDisciplinaAluno(string disciplinaId, string codigoTurma, string codigoAluno);
+
+        Task<IEnumerable<AulaPossuiFrequenciaAulaRegistradaDto>> ObterDatasDeAulasPorAnoTurmaEDisciplinaVerificandoSePossuiFrequenciaAulaRegistrada(IEnumerable<long> periodosEscolaresId, int anoLetivo, string turmaCodigo,
+                string disciplinaId, string usuarioRF, DateTime? aulaInicio, DateTime? aulaFim, bool aulaCj);
     }
 }

--- a/src/SME.SGP.Infra/Dtos/AulaPossuiFrequenciaAulaRegistradaDto.cs
+++ b/src/SME.SGP.Infra/Dtos/AulaPossuiFrequenciaAulaRegistradaDto.cs
@@ -1,14 +1,13 @@
-﻿using SME.SGP.Dominio;
-using System;
+﻿using System;
+using SME.SGP.Dominio;
 
 namespace SME.SGP.Infra
 {
-    public class DataAulasProfessorDto
+    public class AulaPossuiFrequenciaAulaRegistradaDto
     {
-        public DateTime Data { get; set; }
-        public long IdAula { get; set; }
+        public long Id { get; set; }
+        public DateTime DataAula { get; set; }
         public bool AulaCJ { get; set; }
-        public int Bimestre { get; set; }
         public string ProfessorRf { get; set; }
         public string CriadoPor { get; set; }
         public TipoAula TipoAula { get; set; }


### PR DESCRIPTION
Alterado a query ObterDatasAulasPorProfessorEComponenteQuery.
Alterado a carga de PossuiFrequenciaRegistrada, removido a consulta de dentro do loop de aulas 
Criado ObterDatasDeAulasPorAnoTurmaEDisciplinaVerificandoSePossuiFrequenciaAulaRegistrada , para não alterar o ObterDatasDeAulasPorAnoTurmaEDisciplina que já é utilizado em outros lugares e devolve a entidade Aula
e criado AulaPossuiFrequenciaAulaRegistradaDto para retorno do ObterDatasDeAulasPorAnoTurmaEDisciplinaVerificandoSePossuiFrequenciaAulaRegistrada somente com os campos que o ObterAulasNosPeriodos precisa

[AB#68388](https://dev.azure.com/amcomgov/c1dcf343-60ee-40b6-a30a-3b9c12c6d220/_workitems/edit/68388)