### PR TITLE
Inconsistência ao salvar uma nota numérica pós-conselho em branco

### DIFF
--- a/src/SME.SGP.Aplicacao/Consultas/ConsultasConselhoClasseAluno.cs
+++ b/src/SME.SGP.Aplicacao/Consultas/ConsultasConselhoClasseAluno.cs
@@ -673,7 +673,7 @@ namespace SME.SGP.Aplicacao
             // Busca nota do conselho de classe consultado
             var notaComponente = notasConselhoClasseAluno.FirstOrDefault(c => c.ComponenteCurricularCodigo == componenteCurricularCodigo);
             var notaComponenteId = notaComponente?.Id;
-            if (notaComponente == null || !notaComponente.NotaConceito.HasValue)
+            if (notaComponente == null)
             {
                 var notaComponenteFechamento =
                     notasFechamentoAluno.FirstOrDefault(c => c.ComponenteCurricularCodigo == componenteCurricularCodigo && c.Bimestre == bimestre && c.ConselhoClasseNotaId > 0)


### PR DESCRIPTION
[AB#70105](https://dev.azure.com/amcomgov/c1dcf343-60ee-40b6-a30a-3b9c12c6d220/_workitems/edit/70105)