### PR TITLE
Notificações travadas para o supervisor

### DIFF
--- a/src/SME.SGP.Aplicacao/Queries/FechamentoReabertura/ObterNotificacaoParaExcluirPorFechamentoReabertura/ObterNotificacaoParaExcluirPorFechamentoReaberturaIdQuery.cs
+++ b/src/SME.SGP.Aplicacao/Queries/FechamentoReabertura/ObterNotificacaoParaExcluirPorFechamentoReabertura/ObterNotificacaoParaExcluirPorFechamentoReaberturaIdQuery.cs
@@ -1,0 +1,23 @@
+﻿using FluentValidation;
+using MediatR;
+
+namespace SME.SGP.Aplicacao
+{
+    public class ObterNotificacaoParaExcluirPorFechamentoReaberturaIdQuery:IRequest<long>
+    {
+        public ObterNotificacaoParaExcluirPorFechamentoReaberturaIdQuery(long fechamentoReaberturaId)
+        {
+            FechamentoReaberturaId = fechamentoReaberturaId;
+        }
+
+        public long FechamentoReaberturaId { get; set; }
+    }
+
+    public class ObterNotificacaoParaExcluirPorFechamentoReaberturaIdQueryValidator : AbstractValidator<ObterNotificacaoParaExcluirPorFechamentoReaberturaIdQuery>
+    {
+        public ObterNotificacaoParaExcluirPorFechamentoReaberturaIdQueryValidator()
+        {
+            RuleFor(x => x.FechamentoReaberturaId).NotEmpty().WithMessage("Informe o Id do Fechamanto para consultar se existe notificação");
+        }
+    }
+}

--- a/src/SME.SGP.Aplicacao/Queries/FechamentoReabertura/ObterNotificacaoParaExcluirPorFechamentoReabertura/ObterNotificacaoParaExcluirPorFechamentoReaberturaIdQueryHandler.cs
+++ b/src/SME.SGP.Aplicacao/Queries/FechamentoReabertura/ObterNotificacaoParaExcluirPorFechamentoReabertura/ObterNotificacaoParaExcluirPorFechamentoReaberturaIdQueryHandler.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using MediatR;
+using SME.SGP.Dominio.Interfaces;
+
+namespace SME.SGP.Aplicacao
+{
+    public class ObterNotificacaoParaExcluirPorFechamentoReaberturaIdQueryHandler : IRequestHandler<ObterNotificacaoParaExcluirPorFechamentoReaberturaIdQuery,long>
+    {
+        private readonly IRepositorioFechamentoReabertura repositorioReabertura;
+
+        public ObterNotificacaoParaExcluirPorFechamentoReaberturaIdQueryHandler(IRepositorioFechamentoReabertura reabertura)
+        {
+            repositorioReabertura = reabertura ?? throw new ArgumentNullException(nameof(reabertura));
+        }
+
+        public async Task<long> Handle(ObterNotificacaoParaExcluirPorFechamentoReaberturaIdQuery request, CancellationToken cancellationToken)
+        {
+            return await repositorioReabertura.ObterNotificacaoParaExcluirPorFechamentoReaberturaId(request.FechamentoReaberturaId);
+        }
+    }
+}

--- a/src/SME.SGP.Dados/Repositorios/RepositorioFechamentoReabertura.cs
+++ b/src/SME.SGP.Dados/Repositorios/RepositorioFechamentoReabertura.cs
@@ -350,5 +350,19 @@ namespace SME.SGP.Dados.Repositorios
                 tipoCalendarioId
             });
         }
+
+        public async Task<long> ObterNotificacaoParaExcluirPorFechamentoReaberturaId(long fechamentoReaberturaId)
+        {
+            var query =@"select n.id 
+                         from wf_aprovacao wf
+                          inner join wf_aprovacao_nivel wfn on wfn.wf_aprovacao_id = wf.id 
+                          join wf_aprovacao_nivel_notificacao wfnn on wfnn.wf_aprovacao_nivel_id = wfn.id
+                          join notificacao n on wfnn.notificacao_id = n.id
+                          JOIN fechamento_reabertura fr ON wf.id = fr.wf_aprovacao_id 
+                        where n.status in(1,2) AND n.categoria =2 AND n.tipo=1
+                        AND NOT n.excluida AND wf.tipo =5 AND fr.id = @fechamentoReaberturaId";
+
+            return await database.Conexao.QueryFirstOrDefaultAsync<long>(sql: query, new {fechamentoReaberturaId});
+        }
     }
 }

--- a/src/SME.SGP.Dominio.Interfaces/Repositorios/IRepositorioFechamentoReabertura.cs
+++ b/src/SME.SGP.Dominio.Interfaces/Repositorios/IRepositorioFechamentoReabertura.cs
@@ -29,5 +29,6 @@ namespace SME.SGP.Dominio.Interfaces
 
         Task<FechamentoReabertura> ObterReaberturaFechamentoBimestrePorDataReferencia(int bimestre, DateTime dataReferencia, long tipoCalendarioId, string dreCodigo, string ueCodigo);
         Task<IEnumerable<FechamentoReabertura>> ObterPorIds(long[] ids);
+        Task<long> ObterNotificacaoParaExcluirPorFechamentoReaberturaId(long fechamentoReaberturaId);
     }
 }

--- a/src/SME.SGP.Dominio.Servicos/ServicoFechamentoReabertura.cs
+++ b/src/SME.SGP.Dominio.Servicos/ServicoFechamentoReabertura.cs
@@ -84,6 +84,7 @@ namespace SME.SGP.Dominio.Servicos
 
             if (fechamentoReabertura.Status == EntidadeStatus.AguardandoAprovacao)
             {
+                await RemoverNotificacaoExistente(fechamentoReabertura.Id);
                 fechamentoReabertura.WorkflowAprovacaoId = await PersistirWorkflowFechamentoReabertura(fechamentoReabertura);
                 await repositorioFechamentoReabertura.SalvarAsync(fechamentoReabertura);
                 mensagemRetorno = "Reabertura de Fechamento alterado e será válido após aprovação.";
@@ -91,11 +92,17 @@ namespace SME.SGP.Dominio.Servicos
             else
                 await mediator.Send(new PublicarFilaSgpCommand(RotasRabbitSgpFechamento.RotaNotificacaoFechamentoReabertura, MapearFechamentoReaberturaNotificacao(fechamentoReabertura, usuarioAtual), new System.Guid(), usuarioAtual));
 
+            
             unitOfWork.PersistirTransacao();
 
             return mensagemRetorno;
         }
 
+        private async Task RemoverNotificacaoExistente(long fechamentoReaberturaId)
+        {
+            var notificacaoId = await mediator.Send(new ObterNotificacaoParaExcluirPorFechamentoReaberturaIdQuery(fechamentoReaberturaId));
+            await mediator.Send(new ExcluirNotificacaoPorIdCommand(notificacaoId));
+        }
         private FiltroFechamentoReaberturaNotificacaoDto MapearFechamentoReaberturaNotificacao(FechamentoReabertura fechamentoReabertura, Usuario usuario)
         {
             return new FiltroFechamentoReaberturaNotificacaoDto(fechamentoReabertura.Dre != null ? fechamentoReabertura.Dre.CodigoDre : string.Empty,

--- a/src/SME.SGP.Dominio.Servicos/ServicoFechamentoReabertura.cs
+++ b/src/SME.SGP.Dominio.Servicos/ServicoFechamentoReabertura.cs
@@ -101,7 +101,8 @@ namespace SME.SGP.Dominio.Servicos
         private async Task RemoverNotificacaoExistente(long fechamentoReaberturaId)
         {
             var notificacaoId = await mediator.Send(new ObterNotificacaoParaExcluirPorFechamentoReaberturaIdQuery(fechamentoReaberturaId));
-            await mediator.Send(new ExcluirNotificacaoPorIdCommand(notificacaoId));
+            if(notificacaoId>0)
+               await mediator.Send(new ExcluirNotificacaoPorIdCommand(notificacaoId));
         }
         private FiltroFechamentoReaberturaNotificacaoDto MapearFechamentoReaberturaNotificacao(FechamentoReabertura fechamentoReabertura, Usuario usuario)
         {


### PR DESCRIPTION
Algumas notificações de ação (que dependem de aprovação ou recusa) estão travadas para o usuário. Ele aceita ou recusa, porém elas continuam aparecendo como se não tivesse tomado nenhuma ação.


[AB#63310](https://dev.azure.com/amcomgov/c1dcf343-60ee-40b6-a30a-3b9c12c6d220/_workitems/edit/63310)
[AB#70760](https://dev.azure.com/amcomgov/c1dcf343-60ee-40b6-a30a-3b9c12c6d220/_workitems/edit/70760) 