### PR TITLE
Bug: 78898

### DIFF
--- a/src/SME.SGP.Dados/Repositorios/RepositorioAbrangencia.cs
+++ b/src/SME.SGP.Dados/Repositorios/RepositorioAbrangencia.cs
@@ -794,7 +794,7 @@ namespace SME.SGP.Dados.Repositorios
                     resultadoFiltrado = resultadoFiltrado.Where(r => !anosInfantilDesconsiderar.Contains(r.Ano));
             }
 
-            return resultadoFiltrado.DistinctBy(p => new {p.Nome});
+            return resultadoFiltrado.DistinctBy(p => new {p.Codigo, p.Nome});
         }
 
         public async Task<IEnumerable<string>> ObterLoginsAbrangenciaUePorPerfil(long ueId, Guid perfil, bool historica = false)


### PR DESCRIPTION
Ajuste na listagem de turmas para a abrangência, aplicando a distinção não só pelo nome da turma, mas também pelo código.