### PR TITLE
Ajustes para incluir componente 138 do teste de compensação de ausência.

### DIFF
--- a/teste/SME.SGP.TesteIntegracao/ServicosFakes/ServicoEOLFake.cs
+++ b/teste/SME.SGP.TesteIntegracao/ServicosFakes/ServicoEOLFake.cs
@@ -520,6 +520,11 @@ namespace SME.SGP.TesteIntegracao.ServicosFakes
                 {
                     Codigo = 1106,
                     TerritorioSaber = false
+                },
+                new ComponenteCurricularEol()
+                {
+                    Codigo = 138,
+                    TerritorioSaber = false
                 }
             });
         }


### PR DESCRIPTION
[AB#89870](https://dev.azure.com/amcomgov/c1dcf343-60ee-40b6-a30a-3b9c12c6d220/_workitems/edit/89870)