### PR TITLE
fix/91681

### DIFF
--- a/src/SME.SGP.Aplicacao/CasosDeUso/CompensacaoAusencia/SalvarCompensasaoAusenciaUseCase.cs
+++ b/src/SME.SGP.Aplicacao/CasosDeUso/CompensacaoAusencia/SalvarCompensasaoAusenciaUseCase.cs
@@ -259,6 +259,9 @@ namespace SME.SGP.Aplicacao
                 .Select(t => new AlunoQuantidadeCompensacaoDto(t.CodigoAluno, t.QuantidadeFaltasCompensadas))
                 .Distinct();
 
+            if (turma.AnoLetivo < 2023)
+                return codigosAlunosQtdeCompensacao.Select(t => t.CodigoAluno);
+
             var faltasNaoCompensadas = await mediator.Send(new ObterAusenciaParaCompensacaoQuery(
                 compensacao.Id,
                 turma.CodigoTurma,


### PR DESCRIPTION
[AB#91681](https://dev.azure.com/amcomgov/c1dcf343-60ee-40b6-a30a-3b9c12c6d220/_workitems/edit/91681)  Não armazenar os dados na tabela compensacao_ausencia_aluno_aula para anos anteriores, para não entrar na consolidação mensal