### PR TITLE
Command estava com contexto de leitura

### DIFF
--- a/src/SME.SGP.Aplicacao/Commands/Fechamento/IncluirFechamentoFinal/IncluirFechamentoFinalCommandHandler.cs
+++ b/src/SME.SGP.Aplicacao/Commands/Fechamento/IncluirFechamentoFinal/IncluirFechamentoFinalCommandHandler.cs
@@ -8,9 +8,9 @@ namespace SME.SGP.Aplicacao
 {
     public class IncluirFechamentoFinalCommandHandler : IRequestHandler<IncluirFechamentoFinalCommand, long>
     {
-        private readonly IRepositorioFechamentoTurmaConsulta repositorioFechamentoTurma;
+        private readonly IRepositorioFechamentoTurma repositorioFechamentoTurma;
 
-        public IncluirFechamentoFinalCommandHandler(IRepositorioFechamentoTurmaConsulta repositorioFechamentoTurma)
+        public IncluirFechamentoFinalCommandHandler(IRepositorioFechamentoTurma repositorioFechamentoTurma)
         {
             this.repositorioFechamentoTurma = repositorioFechamentoTurma ?? throw new System.ArgumentNullException(nameof(repositorioFechamentoTurma));
         }


### PR DESCRIPTION
[AB#102195](https://dev.azure.com/amcomgov/c1dcf343-60ee-40b6-a30a-3b9c12c6d220/_workitems/edit/102195)