### PR TITLE
Bug: 112095

### DIFF
--- a/src/SME.SGP.Aplicacao/Commands/Aulas/AlterarAulaRecorrente/AlterarAulaRecorrenteCommand.cs
+++ b/src/SME.SGP.Aplicacao/Commands/Aulas/AlterarAulaRecorrente/AlterarAulaRecorrenteCommand.cs
@@ -5,8 +5,10 @@ using System;
 
 namespace SME.SGP.Aplicacao
 {
-    public class AlterarAulaRecorrenteCommand: IRequest<bool>
+    public class AlterarAulaRecorrenteCommand : IRequest<bool>
     {
+        public AlterarAulaRecorrenteCommand() { }
+
         public AlterarAulaRecorrenteCommand(IncluirFilaAlteracaoAulaRecorrenteCommand aulaRecorrente)
         {
             Usuario = aulaRecorrente.Usuario;

--- a/teste/SME.SGP.Aplicacao.Teste/Commands/Aulas/AlterarAulaRecorrenteCommandTeste.cs
+++ b/teste/SME.SGP.Aplicacao.Teste/Commands/Aulas/AlterarAulaRecorrenteCommandTeste.cs
@@ -1,0 +1,15 @@
+﻿using Xunit;
+
+namespace SME.SGP.Aplicacao.Teste.Commands.Aulas
+{
+    public class AlterarAulaRecorrenteCommandTeste
+    {
+        [Fact(DisplayName = "AlterarAulaRecorrenteCommand - Deve verificar se a classe possui construtor sem parâmetros")]
+        public void DeveVerificarSeAlterarAulaRecorrenteCommandPossuiContrutorSemParametros()
+        {
+            var classeCommand = typeof(AlterarAulaRecorrenteCommand);
+
+            Assert.Contains(classeCommand.GetConstructors(), c => c.GetParameters().Length == 0);
+        }
+    }
+}


### PR DESCRIPTION
Ajuste no command de alterar aulas recorrentes incluindo o construtor sem parâmetros, pois algumas mensagens da fila não possuem o valor esperado no construtor com os parâmetros. Dessa forma prevenindo o erro de objeto nulo.