### PR TITLE
Bug: 120344

### DIFF
--- a/src/SME.SGP.Api/Controllers/FechamentoTurmaController.cs
+++ b/src/SME.SGP.Api/Controllers/FechamentoTurmaController.cs
@@ -62,7 +62,7 @@ namespace SME.SGP.Api.Controllers
         [ProducesResponseType(typeof(RetornoBaseDto), 601)]
         [Permissao(Permissao.CP_I, Policy = "Bearer")]
         public async Task<IActionResult> Processar([FromBody] IEnumerable<FechamentoTurmaDisciplinaDto> fechamentoTurma, [FromServices] IComandosFechamentoTurmaDisciplina comandos)
-            => Ok(await comandos.Salvar(fechamentoTurma, true));
+            => Ok(await comandos.Salvar(fechamentoTurma, true, true));
 
         [HttpPost("anotacoes/alunos/")]
         [ProducesResponseType(typeof(AuditoriaPersistenciaDto), 200)]

--- a/src/SME.SGP.Aplicacao/Comandos/ComandosFechamentoTurmaDisciplina.cs
+++ b/src/SME.SGP.Aplicacao/Comandos/ComandosFechamentoTurmaDisciplina.cs
@@ -38,7 +38,7 @@ namespace SME.SGP.Aplicacao
                 await Reprocessar(id, usuario);
         }
 
-        public async Task<IEnumerable<AuditoriaPersistenciaDto>> Salvar(IEnumerable<FechamentoTurmaDisciplinaDto> fechamentosTurma, bool componenteSemNota = false)
+        public async Task<IEnumerable<AuditoriaPersistenciaDto>> Salvar(IEnumerable<FechamentoTurmaDisciplinaDto> fechamentosTurma, bool componenteSemNota = false, bool processamento = false)
         {
             var listaAuditoria = new List<AuditoriaPersistenciaDto>();
             
@@ -55,7 +55,7 @@ namespace SME.SGP.Aplicacao
                             throw new NegocioException("Justificativa não pode ter mais que " + limite + " caracteres");
                     }
                     
-                    listaAuditoria.Add(await servicoFechamentoTurmaDisciplina.Salvar(fechamentoTurma.Id, fechamentoTurma, componenteSemNota));
+                    listaAuditoria.Add(await servicoFechamentoTurmaDisciplina.Salvar(fechamentoTurma.Id, fechamentoTurma, componenteSemNota, processamento));
                     await RemoverCacheFechamento(fechamentoTurma);
                 }
                 catch (Exception e)

--- a/src/SME.SGP.Aplicacao/Interfaces/Comandos/IComandosFechamentoTurmaDisciplina.cs
+++ b/src/SME.SGP.Aplicacao/Interfaces/Comandos/IComandosFechamentoTurmaDisciplina.cs
@@ -7,7 +7,7 @@ namespace SME.SGP.Aplicacao
 {
     public interface IComandosFechamentoTurmaDisciplina
     {
-        Task<IEnumerable<AuditoriaPersistenciaDto>> Salvar(IEnumerable<FechamentoTurmaDisciplinaDto> fechamentosTurma, bool componenteSemNota = false);
+        Task<IEnumerable<AuditoriaPersistenciaDto>> Salvar(IEnumerable<FechamentoTurmaDisciplinaDto> fechamentosTurma, bool componenteSemNota = false, bool processamento = false);
         Task Reprocessar(long fechamentoId, Usuario usuario = null);
         Task Reprocessar(IEnumerable<long> fechamentoId, Usuario usuario = null);
         Task ProcessarPendentes(int anoLetivo);

--- a/src/SME.SGP.Dominio.Interfaces/Servicos/IServicoFechamentoTurmaDisciplina.cs
+++ b/src/SME.SGP.Dominio.Interfaces/Servicos/IServicoFechamentoTurmaDisciplina.cs
@@ -5,7 +5,7 @@ namespace SME.SGP.Dominio.Interfaces
 {
     public interface IServicoFechamentoTurmaDisciplina
     {
-        Task<AuditoriaPersistenciaDto> Salvar(long id, FechamentoTurmaDisciplinaDto entidadeDto, bool componenteSemNota = false);
+        Task<AuditoriaPersistenciaDto> Salvar(long id, FechamentoTurmaDisciplinaDto entidadeDto, bool componenteSemNota = false, bool processamento = false);
 
         Task Reprocessar(long fechamentoId, Usuario usuario = null);
 


### PR DESCRIPTION
Inclusão de verificação ao disparar o processamento de fechamento não aplicar a validação alunos inativos com notas fora do período de fechamento. Essa validação se aplica no lançamento da nota.