### PR TITLE
Bug: 123387

### DIFF
--- a/src/SME.SGP.Dominio/Entidades/Aula.cs
+++ b/src/SME.SGP.Dominio/Entidades/Aula.cs
@@ -71,7 +71,7 @@ namespace SME.SGP.Dominio
 
         public bool Excluido { get; set; }
         public bool Migrado { get; set; }
-        public bool PermiteSubstituicaoFrequencia => !(EhAEE || EhAEEContraturno || EhRecuperacaoParalela);
+        public bool PermiteSubstituicaoFrequencia => !(EhAEE || EhAEEContraturno);
 
         public string ProfessorRf { get; set; }
 


### PR DESCRIPTION
Ajuste no processo de registrar frequência removendo a validação se permite substituição de frequência desconsiderando os componentes antigos de PAP de recuperação paralela.