### PR TITLE
Refactor supervisor assignment handling and SQL query

### DIFF
--- a/src/SME.SGP.Aplicacao/Consultas/ConsultasSupervisor.cs
+++ b/src/SME.SGP.Aplicacao/Consultas/ConsultasSupervisor.cs
@@ -103,6 +103,7 @@ namespace SME.SGP.Aplicacao
 
             var perfilAtual = servicoUsuario.ObterPerfilAtual();
             var listaCodigoSupervisor = filtro.SupervisorId.NaoEhNulo() ? filtro.SupervisorId.Split(",").ToArray() : new string[] { };
+            var responsavelEscolaDreDtoComTiposNaoExistente = new List<SupervisorEscolasDreDto>();
 
             if (responsavelEscolaDreDto.Count > 0)
             {
@@ -130,34 +131,38 @@ namespace SME.SGP.Aplicacao
                                 AtribuicaoExcluida = true,
                                 UeId = supervisorEscolasDreDto.FirstOrDefault().UeId,
                             };
-                            responsavelEscolaDreDto.Add(registro);
+                            responsavelEscolaDreDtoComTiposNaoExistente.Add(registro);
                         }
                     }
                 }
 
+                responsavelEscolaDreDtoComTiposNaoExistente = responsavelEscolaDreDtoComTiposNaoExistente.Concat(responsavelEscolaDreDto).ToList();
+
+                responsavelEscolaDreDtoComTiposNaoExistente = [.. responsavelEscolaDreDtoComTiposNaoExistente.Where(x => x.TipoAtribuicao != 0)];
+
                 if (!string.IsNullOrEmpty(filtro.UeCodigo) && !filtro.UESemResponsavel)
-                    responsavelEscolaDreDto = responsavelEscolaDreDto.Where(x => x.UeId == filtro.UeCodigo).ToList();
+                    responsavelEscolaDreDtoComTiposNaoExistente = responsavelEscolaDreDtoComTiposNaoExistente.Where(x => x.UeId == filtro.UeCodigo).ToList();
 
                 if (filtro.TipoCodigo > 0)
-                    responsavelEscolaDreDto = responsavelEscolaDreDto.Where(x => x.TipoAtribuicao == filtro.TipoCodigo).ToList();
+                    responsavelEscolaDreDtoComTiposNaoExistente = responsavelEscolaDreDtoComTiposNaoExistente.Where(x => x.TipoAtribuicao == filtro.TipoCodigo).ToList();
                 else
                 {
                     if (perfilAtual == Perfis.PERFIL_CEFAI)
-                        responsavelEscolaDreDto = responsavelEscolaDreDto.Where(f => f.TipoAtribuicao.Equals((int)TipoResponsavelAtribuicao.PAAI)).ToList();
+                        responsavelEscolaDreDtoComTiposNaoExistente = responsavelEscolaDreDtoComTiposNaoExistente.Where(f => f.TipoAtribuicao.Equals((int)TipoResponsavelAtribuicao.PAAI)).ToList();
                     else if (perfilAtual == Perfis.PERFIL_COORDENADOR_NAAPA)
-                        responsavelEscolaDreDto = responsavelEscolaDreDto.Where(f => f.TipoAtribuicao.Equals((int)TipoResponsavelAtribuicao.AssistenteSocial) ||
+                        responsavelEscolaDreDtoComTiposNaoExistente = responsavelEscolaDreDtoComTiposNaoExistente.Where(f => f.TipoAtribuicao.Equals((int)TipoResponsavelAtribuicao.AssistenteSocial) ||
                                                                                      f.TipoAtribuicao.Equals((int)TipoResponsavelAtribuicao.PsicologoEscolar) ||
                                                                                      f.TipoAtribuicao.Equals((int)TipoResponsavelAtribuicao.Psicopedagogo)).ToList();
                 }
 
                 if (listaCodigoSupervisor.Any())
-                    responsavelEscolaDreDto = responsavelEscolaDreDto.Where(x => listaCodigoSupervisor.Contains(x.SupervisorId) && !x.AtribuicaoExcluida).ToList();
+                    responsavelEscolaDreDtoComTiposNaoExistente = responsavelEscolaDreDtoComTiposNaoExistente.Where(x => listaCodigoSupervisor.Contains(x.SupervisorId) && !x.AtribuicaoExcluida).ToList();
 
                 if (filtro.SupervisorId?.Length == 0 || filtro.SupervisorId.EhNulo() && filtro.UESemResponsavel || filtro.UESemResponsavel)
-                    responsavelEscolaDreDto = responsavelEscolaDreDto.Where(x => x.AtribuicaoExcluida).ToList();
+                    responsavelEscolaDreDtoComTiposNaoExistente = responsavelEscolaDreDtoComTiposNaoExistente.Where(x => x.AtribuicaoExcluida).ToList();
             }
 
-            return responsavelEscolaDreDto.OrderBy(x => x.Nome).ToList();
+            return responsavelEscolaDreDtoComTiposNaoExistente.OrderBy(x => x.TipoEscola).ThenBy(x => x.Nome).ToList();
         }
 
         private static void TrataEscolasSemResponsaveis(IEnumerable<AbrangenciaUeRetorno> escolasPorDre, List<ResponsavelEscolasDto> listaRetorno)

--- a/src/SME.SGP.Dados/Repositorios/RepositorioSupervisorEscolaDre.cs
+++ b/src/SME.SGP.Dados/Repositorios/RepositorioSupervisorEscolaDre.cs
@@ -115,30 +115,30 @@ namespace SME.SGP.Dados.Repositorios
         }
         public async Task<List<SupervisorEscolasDreDto>> ObterTodosAtribuicaoResponsavelPorDreCodigo(string dreCodigo)
         {
-            StringBuilder query = new();
-
-            query.AppendLine(@"SELECT 
-                                sed.id as AtribuicaoSupervisorId,
-                                 sed.dre_id AS DreId,
-                                 sed.escola_id AS UeId,
-                                 sed.supervisor_id AS SupervisorId,
-                                 sed.criado_em AS CriadoEm,
-                                 sed.criado_por AS CriadoPor,
-                                 sed.alterado_em AS AlteradoEm,
-                                 sed.alterado_por AS AlteradoPor,
-                                 sed.criado_rf AS CriadoRf,
-                                 sed.alterado_rf AS AlteradoRf,
-                                 sed.excluido AtribuicaoExcluida,
-                                 sed.tipo AS TipoAtribuicao,
-                                 d.abreviacao  AS DreNome,
-                                 u.nome AS UeNome,
-                                 u.tipo_escola AS TipoEscola
-                            FROM supervisor_escola_dre sed
-                             INNER JOIN dre d ON sed.dre_id = d.dre_id
-                             INNER JOIN ue u ON u.ue_id  = sed.escola_id 
-                            WHERE sed.dre_id = @dreCodigo 
-                                and not sed.excluido
-                            ORDER BY u.tipo_escola ,u.nome ");
+            StringBuilder query = new(); 
+            
+            query.AppendLine(@"
+            SELECT 
+                sed.id as AtribuicaoSupervisorId,
+                 sed.dre_id AS DreId,
+                 u.ue_id AS UeId,
+                 sed.supervisor_id AS SupervisorId,
+                 sed.criado_em AS CriadoEm,
+                 sed.criado_por AS CriadoPor,
+                 sed.alterado_em AS AlteradoEm,
+                 sed.alterado_por AS AlteradoPor,
+                 sed.criado_rf AS CriadoRf,
+                 sed.alterado_rf AS AlteradoRf,
+                 sed.excluido AtribuicaoExcluida,
+                 sed.tipo AS TipoAtribuicao,
+                 d.abreviacao  AS DreNome,
+                 u.nome AS UeNome,
+                 u.tipo_escola AS TipoEscola
+            FROM ue u
+            INNER JOIN dre d ON u.dre_id =d.id
+            LEFT JOIN supervisor_escola_dre sed ON u.ue_id  = sed.escola_id and not sed.excluido
+            WHERE d.dre_id = @dreCodigo
+            ORDER BY u.tipo_escola ,u.nome ");
 
             var consulta = await database.Conexao.QueryAsync<SupervisorEscolasDreDto>(query.ToString(), new { dreCodigo });
             return consulta.ToList();


### PR DESCRIPTION
Introduced a new list, `responsavelEscolaDreDtoComTiposNaoExistente`, in `ConsultasSupervisor.cs` to store supervisor school assignments without certain types. Updated filtering operations to apply to this new list and modified the return statement to order by `TipoEscola` and `Nome`.

In `RepositorioSupervisorEscolaDre.cs`, modified the SQL query to use a `LEFT JOIN` for a more comprehensive retrieval of school and supervisor assignment data, ensuring inclusion of schools without assigned supervisors.