### PR TITLE
Correct the filtering operation

### DIFF
--- a/src/SME.SGP.Aplicacao/Consultas/ConsultasSupervisor.cs
+++ b/src/SME.SGP.Aplicacao/Consultas/ConsultasSupervisor.cs
@@ -138,7 +138,7 @@ namespace SME.SGP.Aplicacao
 
                 responsavelEscolaDreDtoComTiposNaoExistente = responsavelEscolaDreDtoComTiposNaoExistente.Concat(responsavelEscolaDreDto).ToList();
 
-                responsavelEscolaDreDtoComTiposNaoExistente = [.. responsavelEscolaDreDtoComTiposNaoExistente.Where(x => x.TipoAtribuicao != 0)];
+                responsavelEscolaDreDtoComTiposNaoExistente = responsavelEscolaDreDtoComTiposNaoExistente.Where(x => x.TipoAtribuicao != 0).ToList();
 
                 if (!string.IsNullOrEmpty(filtro.UeCodigo) && !filtro.UESemResponsavel)
                     responsavelEscolaDreDtoComTiposNaoExistente = responsavelEscolaDreDtoComTiposNaoExistente.Where(x => x.UeId == filtro.UeCodigo).ToList();


### PR DESCRIPTION
#### PR Classification
Code cleanup to correct the filtering operation.

#### PR Summary
The pull request refines the filtering logic for `responsavelEscolaDreDtoComTiposNaoExistente` to ensure it correctly converts the filtered results into a list. 
- ConsultasSupervisor.cs: Changed the filtering operation to use `ToList()` instead of square brackets for proper list conversion.
