### PR TITLE
Add HTTP client mocking for integration tests

### DIFF
--- a/teste/SME.SGP.TesteIntegracao/Abrangencia/Ao_obter_abrangencia_perfil_poa.cs
+++ b/teste/SME.SGP.TesteIntegracao/Abrangencia/Ao_obter_abrangencia_perfil_poa.cs
@@ -12,9 +12,14 @@ using SME.SGP.TesteIntegracao.Abrangencia.Base;
 using SME.SGP.TesteIntegracao.Abrangencia.Fake;
 using SME.SGP.TesteIntegracao.Setup;
 using System;
+using System.Collections.Generic;
 using System.Linq;
+using System.Net.Http;
+using System.Net;
 using System.Threading.Tasks;
 using Xunit;
+using Newtonsoft.Json;
+using Microsoft.Extensions.Configuration;
 
 namespace SME.SGP.TesteIntegracao.Abrangencia
 {
@@ -175,6 +180,21 @@ namespace SME.SGP.TesteIntegracao.Abrangencia
         [Fact(DisplayName = "Abrangência - Obter turmas da abrangência para perfil POA")]
         public async Task Ao_obter_turmas_abrangencia_perfil_poa()
         {
+            // ARRANGE - Configuração do cenário HTTP FAKE
+            var turmasEolFake = new List<TurmaApiEolDto>
+            {
+                // Simula que a API do EOL retornou a turma que o SGP irá procurar.
+                new TurmaApiEolDto { Codigo = int.Parse(TURMA_CODIGO_1) }
+            };
+
+            var jsonResposta = JsonConvert.SerializeObject(turmasEolFake);
+            var conteudoHttp = new StringContent(jsonResposta, System.Text.Encoding.UTF8, "application/json");
+
+            // A URL aqui é um prefixo. A implementação do handler usará 'StartsWith' para encontrá-la.
+            var urlApiEol = ServiceProvider.GetService<IConfiguration>()["UrlApiEOL"];
+            RegistradorDependenciasTeste.HttpHandlerFake.AdicionarCenario(urlApiEol, HttpStatusCode.OK, conteudoHttp);
+
+            // ARRANGE - Continuação do setup do teste
             var filtro = new FiltroTesteDto()
             {
                 Perfil = ObterPerfilPOA_Portugues(),

--- a/teste/SME.SGP.TesteIntegracao/Setup/CollectionFixture.cs
+++ b/teste/SME.SGP.TesteIntegracao/Setup/CollectionFixture.cs
@@ -5,6 +5,7 @@ using SME.SGP.Dados;
 using SME.SGP.Infra;
 using System;
 using System.Collections.Generic;
+using System.Configuration;
 using System.Data;
 using System.Globalization;
 using System.Text;
@@ -17,7 +18,7 @@ namespace SME.SGP.TesteIntegracao.Setup
         public IServiceCollection Services { get; set; }
         public InMemoryDatabase Database { get; }
         public ServiceProvider ServiceProvider { get; set; }
-        
+
         public CollectionFixture()
         {
             Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
@@ -41,7 +42,7 @@ namespace SME.SGP.TesteIntegracao.Setup
 
             Services.AddSingleton<IConfiguration>(config);
             Services.AddMemoryCache();
-            
+
             FluentMapper.EntityMaps.Clear();
 
             var culture = CultureInfo.CreateSpecificCulture("pt-BR");
@@ -50,7 +51,11 @@ namespace SME.SGP.TesteIntegracao.Setup
             CultureInfo.DefaultThreadCurrentCulture = culture;
             CultureInfo.DefaultThreadCurrentUICulture = culture;
 
-            new RegistradorDependencias().Registrar(Services, config);
+            var registraDependencias = new RegistradorDependenciasTeste();
+            registraDependencias.Registrar(Services, config);
+            registraDependencias.RegistrarGoogleClassroomSync(Services, config);
+            registraDependencias.RegistrarHttpClients(Services, config);
+            registraDependencias.RegistrarPolicies(Services);
         }
 
         public void BuildServiceProvider()
@@ -62,6 +67,7 @@ namespace SME.SGP.TesteIntegracao.Setup
         public void Dispose()
         {
             Database.Dispose();
+            GC.SuppressFinalize(this);
         }
     }
 

--- a/teste/SME.SGP.TesteIntegracao/Setup/FakeHttpMessageHandler.cs
+++ b/teste/SME.SGP.TesteIntegracao/Setup/FakeHttpMessageHandler.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SME.SGP.TesteIntegracao.Setup
+{
+    public class FakeHttpMessageHandler : HttpMessageHandler
+    {
+        private readonly Dictionary<string, HttpResponseMessage> _cenarios;
+
+        public FakeHttpMessageHandler()
+        {
+            _cenarios = new Dictionary<string, HttpResponseMessage>();
+        }
+
+        public void AdicionarCenario(string url, HttpStatusCode statusCode, HttpContent conteudo)
+        {
+            if (string.IsNullOrEmpty(url))
+                throw new ArgumentNullException(nameof(url), "A URL para o cenário do FakeHttpMessageHandler não pode ser nula ou vazia. Verifique se a chave de configuração da API existe no appsettings.json do projeto de teste.");
+
+            var resposta = new HttpResponseMessage(statusCode) { Content = conteudo };
+            if (!_cenarios.ContainsKey(url))
+                _cenarios.Add(url, resposta);
+            else
+                _cenarios[url] = resposta;
+        }
+
+        public void LimparCenarios()
+        {
+            _cenarios.Clear();
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var requestUri = request.RequestUri.ToString();
+
+            // Procura por uma URL exata ou que comece com o padrão configurado
+            var chaveCenario = _cenarios.Keys.FirstOrDefault(k => requestUri.StartsWith(k));
+
+            if (chaveCenario != null)
+            {
+                return Task.FromResult(_cenarios[chaveCenario]);
+            }
+
+            // Se nenhum cenário for encontrado, retorna 404 Not Found.
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound) { RequestMessage = request });
+        }
+    }
+}

--- a/teste/SME.SGP.TesteIntegracao/Setup/RegistradorDependenciasTeste.cs
+++ b/teste/SME.SGP.TesteIntegracao/Setup/RegistradorDependenciasTeste.cs
@@ -1,29 +1,38 @@
 ﻿using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
-using SME.SGP.Aplicacao;
+using Microsoft.Extensions.ObjectPool;
+using RabbitMQ.Client;
 using SME.SGP.Aplicacao.Integracoes;
-using SME.SGP.Aplicacao.Servicos;
 using SME.SGP.Dados;
 using SME.SGP.Dados.Contexto;
 using SME.SGP.Dominio;
 using SME.SGP.Dominio.Interfaces;
 using SME.SGP.Infra;
+using SME.SGP.Infra.Consts;
 using SME.SGP.Infra.Contexto;
+using SME.SGP.Infra.Interface;
 using SME.SGP.Infra.Interfaces;
+using SME.SGP.Infra.Utilitarios;
 using SME.SGP.IoC;
 using SME.SGP.TesteIntegracao.ServicosFakes;
+using System;
 using System.Data;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.ObjectPool;
-using RabbitMQ.Client;
-using SME.SGP.Infra.Interface;
-using SME.SGP.Infra.Utilitarios;
 
 namespace SME.SGP.TesteIntegracao.Setup
 {
-    public class RegistradorDependencias : RegistrarDependencias
+    public class RegistradorDependenciasTeste : RegistrarDependencias
     {
+        // Handler único para ser configurado pelos testes
+        public static readonly FakeHttpMessageHandler HttpHandlerFake = new FakeHttpMessageHandler();
+
+        public override void Registrar(IServiceCollection services, IConfiguration configuration)
+        {
+            // Limpa cenários anteriores para garantir o isolamento entre coleções de testes
+            HttpHandlerFake.LimparCenarios();
+            base.Registrar(services, configuration);
+        }
         protected override void RegistrarContextos(IServiceCollection services)
         {
             services.TryAddScoped<IHttpContextAccessor, HttpContextAccessorFake>();
@@ -45,6 +54,28 @@ namespace SME.SGP.TesteIntegracao.Setup
 
             services.TryAddScoped<IUnitOfWork, UnitOfWork>();
             base.RegistrarPolicies(services);
+        }
+
+        public override void RegistrarHttpClients(IServiceCollection services, IConfiguration configuration)
+        {
+            services.AddHttpClient();
+
+            services.AddHttpClient(name: ServicosEolConstants.SERVICO, c =>
+            {
+                c.BaseAddress = new Uri(configuration.GetSection("UrlApiEOL").Value);
+                c.DefaultRequestHeaders.Add("Accept", "application/json");
+                // Adicione outros headers se o handler real os utilizar
+            })
+                .ConfigurePrimaryHttpMessageHandler(() => HttpHandlerFake);
+
+            services.AddHttpClient(name: ServicoSondagemConstants.Servico, c =>
+            {
+                c.BaseAddress = new Uri(configuration.GetSection("UrlApiSondagem").Value);
+                c.DefaultRequestHeaders.Add("Accept", "application/json");
+            })
+                .ConfigurePrimaryHttpMessageHandler(() => HttpHandlerFake);
+
+            // Adicione aqui os outros clients que desejar "mockar", seguindo o mesmo padrão.
         }
 
         protected override void RegistrarServicos(IServiceCollection services)

--- a/teste/SME.SGP.TesteIntegracao/appsettings.json
+++ b/teste/SME.SGP.TesteIntegracao/appsettings.json
@@ -1,10 +1,11 @@
 {
   "UrlFrontEnd": "http://localhost:3000",
+  "UrlApiEOL": "http://localhost:5001/api/eol-fake/",
   "ConfiguracaoArmazenamento": {
     "EndPoint": "",
     "Port": "443",
-    "SecretKey" : "",
-    "AccessKey" : "",
+    "SecretKey": "",
+    "AccessKey": "",
     "BucketTemp": "temp",
     "BucketArquivos": "arquivos",
     "TipoRequisicao": "https"


### PR DESCRIPTION
Introduces FakeHttpMessageHandler to mock HTTP responses in integration tests. Updates dependency registration to use the fake handler for HTTP clients, ensuring test isolation and control over external API calls. Adjusts test setup and appsettings to support the new mocking approach.