### PR TITLE
Add unit tests for controllers and query handlers

### DIFF
--- a/SME.SGP.Api.Teste/Controllers/AcompanhamentoAlunoControllerTeste.cs
+++ b/SME.SGP.Api.Teste/Controllers/AcompanhamentoAlunoControllerTeste.cs
@@ -1,0 +1,169 @@
+﻿using Bogus;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using SME.SGP.Api.Controllers;
+using SME.SGP.Aplicacao.Interfaces;
+using SME.SGP.Infra;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace SME.SGP.Api.Testes.Controllers
+{
+    public class AcompanhamentoAlunoControllerTeste
+    {
+        private readonly AcompanhamentoAlunoController _controller;
+        private readonly Faker _faker;
+
+        public AcompanhamentoAlunoControllerTeste()
+        {
+            _controller = new AcompanhamentoAlunoController();
+            _faker = new Faker("pt_BR");
+        }
+
+        [Fact(DisplayName = "Deve chamar caso de uso para salvar o acompanhamento do aluno")]
+        public async Task DeveChamarUseCase_ParaSalvarAcompanhamentoAluno()
+        {
+            // Arrange
+            var useCaseMock = new Mock<ISalvarAcompanhamentoAlunoUseCase>();
+            var dto = new AcompanhamentoAlunoDto();
+            var retorno = new AcompanhamentoAlunoSemestreAuditoriaDto();
+
+            useCaseMock.Setup(u => u.Executar(dto)).ReturnsAsync(retorno);
+
+            // Act
+            var resultado = await _controller.Salvar(useCaseMock.Object, dto);
+
+            // Assert
+            useCaseMock.Verify(u => u.Executar(dto), Times.Once);
+            var okResult = Assert.IsType<OkObjectResult>(resultado);
+            Assert.Same(retorno, okResult.Value);
+        }
+
+        [Fact(DisplayName = "Deve chamar caso de uso para obter o acompanhamento do aluno")]
+        public async Task DeveChamarUseCase_ParaObterAcompanhamentoAluno()
+        {
+            // Arrange
+            var useCaseMock = new Mock<IObterAcompanhamentoAlunoUseCase>();
+            var turmaId = _faker.Random.Long(1);
+            var alunoId = _faker.Random.AlphaNumeric(8);
+            var semestre = _faker.Random.Int(1, 2);
+            var componenteCurricularId = _faker.Random.Long(1);
+            var retorno = new AcompanhamentoAlunoTurmaSemestreDto();
+
+            useCaseMock.Setup(u => u.Executar(It.Is<FiltroAcompanhamentoTurmaAlunoSemestreDto>(f =>
+                f.TurmaId == turmaId &&
+                f.AlunoId == alunoId &&
+                f.Semestre == semestre
+            ))).ReturnsAsync(retorno);
+
+            // Act
+            var resultado = await _controller.ObterAcompanhamentoAluno(turmaId, alunoId, semestre, componenteCurricularId, useCaseMock.Object);
+
+            // Assert
+            useCaseMock.Verify(u => u.Executar(It.IsAny<FiltroAcompanhamentoTurmaAlunoSemestreDto>()), Times.Once);
+            Assert.IsType<OkObjectResult>(resultado);
+        }
+
+        [Fact(DisplayName = "Deve chamar caso de uso para deletar foto do aluno")]
+        public async Task DeveChamarUseCase_ParaDeletarFoto()
+        {
+            // Arrange
+            var useCaseMock = new Mock<IExcluirFotoAlunoUseCase>();
+            var codigoFoto = Guid.NewGuid();
+            var retorno = new AuditoriaDto();
+
+            useCaseMock.Setup(u => u.Executar(codigoFoto)).ReturnsAsync(retorno);
+
+            // Act
+            var resultado = await _controller.DeletarFotos(codigoFoto, useCaseMock.Object);
+
+            // Assert
+            useCaseMock.Verify(u => u.Executar(codigoFoto), Times.Once);
+            Assert.IsType<OkObjectResult>(resultado);
+        }
+
+        [Fact(DisplayName = "Deve chamar caso de uso para upload de foto")]
+        public async Task DeveChamarUseCase_ParaUploadDeFoto()
+        {
+            // Arrange
+            var useCaseMock = new Mock<ISalvarFotoAcompanhamentoAlunoUseCase>();
+            var retorno = new AuditoriaDto();
+
+            var conteudo = "Arquivo de teste";
+            var stream = new MemoryStream(Encoding.UTF8.GetBytes(conteudo));
+            var arquivoMock = new Mock<IFormFile>();
+            arquivoMock.Setup(a => a.Length).Returns(stream.Length);
+
+            var dto = new AcompanhamentoAlunoDto { File = arquivoMock.Object };
+
+            useCaseMock.Setup(u => u.Executar(dto)).ReturnsAsync(retorno);
+
+            // Act
+            var resultado = await _controller.UploadFoto(dto, useCaseMock.Object);
+
+            // Assert
+            useCaseMock.Verify(u => u.Executar(dto), Times.Once);
+            Assert.IsType<OkObjectResult>(resultado);
+        }
+
+        [Fact(DisplayName = "Deve retornar BadRequest quando a foto para upload estiver vazia")]
+        public async Task DeveRetornarBadRequest_QuandoFotoParaUploadEstiverVazia()
+        {
+            // Arrange
+            var useCaseMock = new Mock<ISalvarFotoAcompanhamentoAlunoUseCase>();
+            var arquivoMock = new Mock<IFormFile>();
+            arquivoMock.Setup(a => a.Length).Returns(0);
+            var dto = new AcompanhamentoAlunoDto { File = arquivoMock.Object };
+
+            // Act
+            var resultado = await _controller.UploadFoto(dto, useCaseMock.Object);
+
+            // Assert
+            Assert.IsType<BadRequestResult>(resultado);
+            useCaseMock.Verify(u => u.Executar(It.IsAny<AcompanhamentoAlunoDto>()), Times.Never);
+        }
+
+        [Fact(DisplayName = "Deve chamar caso de uso para obter fotos do semestre")]
+        public async Task DeveChamarUseCase_ParaObterFotosDoSemestre()
+        {
+            // Arrange
+            var useCaseMock = new Mock<IObterFotosSemestreAlunoUseCase>();
+            var acompanhamentoAlunoSemestreId = _faker.Random.Long(1);
+            var retorno = new List<ArquivoDto>();
+
+            useCaseMock.Setup(u => u.Executar(acompanhamentoAlunoSemestreId)).ReturnsAsync(retorno);
+
+            // Act
+            var resultado = await _controller.ObterFotos(acompanhamentoAlunoSemestreId, useCaseMock.Object);
+
+            // Assert
+            useCaseMock.Verify(u => u.Executar(acompanhamentoAlunoSemestreId), Times.Once);
+            Assert.IsType<OkObjectResult>(resultado);
+        }
+
+        [Fact(DisplayName = "Deve chamar caso de uso para obter validação de percurso")]
+        public async Task DeveChamarUseCase_ParaObterValidacaoPercurso()
+        {
+            // Arrange
+            var useCaseMock = new Mock<IObterValidacaoPercusoRAAUseCase>();
+            var turmaId = _faker.Random.Long(1);
+            var semestre = _faker.Random.Int(1, 2);
+            var retorno = new InconsistenciaPercursoRAADto();
+
+            useCaseMock.Setup(u => u.Executar(It.Is<FiltroInconsistenciaPercursoRAADto>(f => f.TurmaId == turmaId && f.Semestre == semestre)))
+                .ReturnsAsync(retorno);
+
+            // Act
+            var resultado = await _controller.ObterValidacaoPercurso(turmaId, semestre, useCaseMock.Object);
+
+            // Assert
+            useCaseMock.Verify(u => u.Executar(It.IsAny<FiltroInconsistenciaPercursoRAADto>()), Times.Once);
+            Assert.IsType<OkObjectResult>(resultado);
+        }
+    }
+}

--- a/SME.SGP.Api.Teste/Controllers/AcompanhamentoTurmaControllerTeste.cs
+++ b/SME.SGP.Api.Teste/Controllers/AcompanhamentoTurmaControllerTeste.cs
@@ -1,0 +1,82 @@
+﻿using Bogus;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using SME.SGP.Api.Controllers;
+using SME.SGP.Aplicacao.Interfaces;
+using SME.SGP.Dominio;
+using SME.SGP.Infra;
+using SME.SGP.Infra.Dtos;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace SME.SGP.Api.Testes.Controllers
+{
+    public class AcompanhamentoTurmaControllerTeste
+    {
+        private readonly AcompanhamentoTurmaController _controller;
+        private readonly Faker _faker;
+
+        public AcompanhamentoTurmaControllerTeste()
+        {
+            _controller = new AcompanhamentoTurmaController();
+            _faker = new Faker("pt_BR");
+        }
+
+        [Fact(DisplayName = "Deve chamar o caso de uso para salvar o acompanhamento da turma")]
+        public async Task DeveChamarUseCase_ParaSalvarAcompanhamentoTurma()
+        {
+            // Arrange
+            var useCaseMock = new Mock<ISalvarAcompanhamentoTurmaUseCase>();
+            var dto = new AcompanhamentoTurmaDto();
+            var retorno = new AcompanhamentoTurma();
+
+            useCaseMock.Setup(u => u.Executar(dto)).ReturnsAsync(retorno);
+
+            // Act
+            var resultado = await _controller.Salvar(useCaseMock.Object, dto);
+
+            // Assert
+            useCaseMock.Verify(u => u.Executar(dto), Times.Once);
+            var okResult = Assert.IsType<OkObjectResult>(resultado);
+            Assert.Same(retorno, okResult.Value);
+        }
+
+        [Fact(DisplayName = "Deve chamar o caso de uso para obter o apanhado geral")]
+        public async Task DeveChamarUseCase_ParaObterApanhadoGeral()
+        {
+            // Arrange
+            var useCaseMock = new Mock<IObterAcompanhamentoTurmaApanhadoGeralUseCase>();
+            var filtro = new FiltroAcompanhamentoTurmaApanhadoGeral();
+            var retorno = new AcompanhamentoTurmaDto();
+
+            useCaseMock.Setup(u => u.Executar(filtro)).ReturnsAsync(retorno);
+
+            // Act
+            var resultado = await _controller.Obter(filtro, useCaseMock.Object);
+
+            // Assert
+            useCaseMock.Verify(u => u.Executar(filtro), Times.Once);
+            var okResult = Assert.IsType<OkObjectResult>(resultado);
+            Assert.Same(retorno, okResult.Value);
+        }
+
+        [Fact(DisplayName = "Deve chamar o caso de uso para obter o parâmetro de quantidade de imagens")]
+        public async Task DeveChamarUseCase_ParaObterParametroQuantidadeImagens()
+        {
+            // Arrange
+            var useCaseMock = new Mock<IObterParametroQuantidadeImagensPercursoColetivoTurmaUseCase>();
+            var ano = _faker.Random.Int(2020, 2025);
+            var retorno = new ParametroQuantidadeUploadImagemDto();
+
+            useCaseMock.Setup(u => u.Executar(ano)).ReturnsAsync(retorno);
+
+            // Act
+            var resultado = await _controller.ObterParametroQuantidadeImagens(ano, useCaseMock.Object);
+
+            // Assert
+            useCaseMock.Verify(u => u.Executar(ano), Times.Once);
+            var okResult = Assert.IsType<OkObjectResult>(resultado);
+            Assert.Same(retorno, okResult.Value);
+        }
+    }
+}

--- a/teste/SME.SGP.Aplicacao.Teste/Queries/Frequencia/ObterFrequenciaGeralPorAlunosTurmaQueryHandlerTeste.cs
+++ b/teste/SME.SGP.Aplicacao.Teste/Queries/Frequencia/ObterFrequenciaGeralPorAlunosTurmaQueryHandlerTeste.cs
@@ -1,0 +1,81 @@
+﻿using Moq;
+using SME.SGP.Dominio;
+using SME.SGP.Dominio.Interfaces;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace SME.SGP.Aplicacao.Teste.Queries.Frequencia
+{
+    public class ObterFrequenciaGeralPorAlunosTurmaQueryHandlerTeste
+    {
+        private readonly Mock<IRepositorioFrequenciaAlunoDisciplinaPeriodoConsulta> _repositorioFrequenciaMock;
+        private readonly ObterFrequenciaGeralPorAlunosTurmaQueryHandler _handler;
+
+        public ObterFrequenciaGeralPorAlunosTurmaQueryHandlerTeste()
+        {
+            _repositorioFrequenciaMock = new Mock<IRepositorioFrequenciaAlunoDisciplinaPeriodoConsulta>();
+            _handler = new ObterFrequenciaGeralPorAlunosTurmaQueryHandler(_repositorioFrequenciaMock.Object);
+        }
+
+        [Fact(DisplayName = "Deve agrupar e somar as frequências por aluno")]
+        public async Task Handle_QuandoExecutado_DeveAgruparESomarFrequenciasPorAluno()
+        {
+            // Arrange
+            var aluno1Codigo = "ALUNO1";
+            var aluno2Codigo = "ALUNO2";
+            var turmaCodigo = "TURMA1";
+            var query = new ObterFrequenciaGeralPorAlunosTurmaQuery(new[] { aluno1Codigo, aluno2Codigo }, turmaCodigo);
+
+            var frequenciasDoRepositorio = new List<FrequenciaAluno>
+            {
+                // Frequências Aluno 1
+                new FrequenciaAluno { CodigoAluno = aluno1Codigo, TotalAulas = 20, TotalAusencias = 2, TotalCompensacoes = 1 },
+                new FrequenciaAluno { CodigoAluno = aluno1Codigo, TotalAulas = 15, TotalAusencias = 1, TotalCompensacoes = 0 },
+                // Frequências Aluno 2
+                new FrequenciaAluno { CodigoAluno = aluno2Codigo, TotalAulas = 20, TotalAusencias = 5, TotalCompensacoes = 2 }
+            };
+
+            _repositorioFrequenciaMock.Setup(r => r.ObterFrequenciaGeralPorAlunosETurmas(query.CodigosAlunos, query.CodigoTurma))
+                .ReturnsAsync(frequenciasDoRepositorio);
+
+            // Act
+            var resultado = await _handler.Handle(query, CancellationToken.None);
+
+            // Assert
+            Assert.NotNull(resultado);
+            Assert.Equal(2, resultado.Count()); // Deve retornar 2 registros, um para cada aluno.
+
+            var freqAluno1 = resultado.FirstOrDefault(f => f.CodigoAluno == aluno1Codigo);
+            Assert.NotNull(freqAluno1);
+            Assert.Equal(35, freqAluno1.TotalAulas);         // 20 + 15
+            Assert.Equal(3, freqAluno1.TotalAusencias);        // 2 + 1
+            Assert.Equal(1, freqAluno1.TotalCompensacoes);      // 1 + 0
+
+            var freqAluno2 = resultado.FirstOrDefault(f => f.CodigoAluno == aluno2Codigo);
+            Assert.NotNull(freqAluno2);
+            Assert.Equal(20, freqAluno2.TotalAulas);
+            Assert.Equal(5, freqAluno2.TotalAusencias);
+            Assert.Equal(2, freqAluno2.TotalCompensacoes);
+        }
+
+        [Fact(DisplayName = "Deve retornar lista vazia quando o repositório não encontrar frequências")]
+        public async Task Handle_QuandoRepositorioRetornaVazio_DeveRetornarVazio()
+        {
+            // Arrange
+            var query = new ObterFrequenciaGeralPorAlunosTurmaQuery(new[] { "ALUNO_INEXISTENTE" }, "TURMA_X");
+
+            _repositorioFrequenciaMock.Setup(r => r.ObterFrequenciaGeralPorAlunosETurmas(query.CodigosAlunos, query.CodigoTurma))
+                .ReturnsAsync(new List<FrequenciaAluno>());
+
+            // Act
+            var resultado = await _handler.Handle(query, CancellationToken.None);
+
+            // Assert
+            Assert.NotNull(resultado);
+            Assert.Empty(resultado);
+        }
+    }
+}

--- a/teste/SME.SGP.Aplicacao.Teste/Queries/Frequencia/ObterFrequenciasAlunoComponentePorTurmasQueryHandlerTeste.cs
+++ b/teste/SME.SGP.Aplicacao.Teste/Queries/Frequencia/ObterFrequenciasAlunoComponentePorTurmasQueryHandlerTeste.cs
@@ -1,0 +1,119 @@
+﻿using Bogus;
+using MediatR;
+using Moq;
+using SME.SGP.Dominio;
+using SME.SGP.Dominio.Interfaces;
+using SME.SGP.Infra.Dtos;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace SME.SGP.Aplicacao.Teste.Queries.Frequencia
+{
+    public class ObterFrequenciasAlunoComponentePorTurmasQueryHandlerTeste
+    {
+        private readonly Mock<IRepositorioFrequenciaAlunoDisciplinaPeriodoConsulta> _repositorioFrequenciaMock;
+        private readonly Mock<IMediator> _mediatorMock;
+        private readonly ObterFrequenciasAlunoComponentePorTurmasQueryHandler _handler;
+        private readonly Faker _faker;
+
+        public ObterFrequenciasAlunoComponentePorTurmasQueryHandlerTeste()
+        {
+            _repositorioFrequenciaMock = new Mock<IRepositorioFrequenciaAlunoDisciplinaPeriodoConsulta>();
+            _mediatorMock = new Mock<IMediator>();
+            _handler = new ObterFrequenciasAlunoComponentePorTurmasQueryHandler(_repositorioFrequenciaMock.Object, _mediatorMock.Object);
+            _faker = new Faker("pt_BR");
+        }
+
+        [Fact(DisplayName = "Deve consolidar frequências e complementar com aulas sem registro")]
+        public async Task Handle_QuandoExecutado_DeveConsolidarEComplementarFrequencias()
+        {
+            // Arrange
+            var alunoCodigo = "123";
+            var turmasCodigos = new[] { "T1" };
+            var tipoCalendarioId = 1L;
+            var disciplinaIdExistente = "D1";
+            var disciplinaIdNova = "D2";
+
+            var query = new ObterFrequenciasAlunoComponentePorTurmasQuery(alunoCodigo, turmasCodigos, tipoCalendarioId, null, 0);
+
+            var frequenciaExistente = new List<FrequenciaAluno>
+            {
+                new FrequenciaAluno { DisciplinaId = disciplinaIdExistente, TotalAulas = 10, TotalAusencias = 2, Bimestre = 1 }
+            };
+
+            var aulasComponentes = new List<TurmaComponenteQntAulasDto>
+            {
+                // Componente que já tem frequência
+                new TurmaComponenteQntAulasDto { TurmaCodigo = "T1", ComponenteCurricularCodigo = disciplinaIdExistente, Bimestre = 1 },
+                // Novo componente que não tem frequência registrada, mas tem aulas
+                new TurmaComponenteQntAulasDto { TurmaCodigo = "T1", ComponenteCurricularCodigo = disciplinaIdNova, Bimestre = 2, AulasQuantidade = 5 }
+            };
+
+            _repositorioFrequenciaMock.Setup(r => r.ObterFrequenciaComponentesAlunoPorTurmas(alunoCodigo, turmasCodigos, tipoCalendarioId, 0))
+                .ReturnsAsync(frequenciaExistente);
+            _mediatorMock.Setup(m => m.Send(It.IsAny<ObterBimestresPorTipoCalendarioQuery>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new int[] { 1, 2 });
+            _mediatorMock.Setup(m => m.Send(It.IsAny<ObterTotalAulasTurmaEBimestreEComponenteCurricularQuery>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(aulasComponentes);
+
+            // Act
+            var resultado = await _handler.Handle(query, CancellationToken.None);
+
+            // Assert
+            Assert.Equal(2, resultado.Count()); // Deve retornar os 2 componentes (o existente e o novo)
+
+            var freqExistenteConsolidada = resultado.FirstOrDefault(f => f.DisciplinaId == disciplinaIdExistente);
+            Assert.NotNull(freqExistenteConsolidada);
+            Assert.Equal(10, freqExistenteConsolidada.TotalAulas);
+            Assert.Equal(2, freqExistenteConsolidada.TotalAusencias);
+
+            var freqNovaConsolidada = resultado.FirstOrDefault(f => f.DisciplinaId == disciplinaIdNova);
+            Assert.NotNull(freqNovaConsolidada);
+            Assert.Equal(0, freqNovaConsolidada.TotalAulas); // A soma do total de aulas vem do objeto FrequenciaAluno, que para o novo é 0.
+        }
+
+        [Fact(DisplayName = "Deve agrupar e somar as frequências por componente")]
+        public async Task Handle_QuandoComponenteTemMultiplosBimestres_DeveAgruparESomar()
+        {
+            // Arrange
+            var alunoCodigo = "123";
+            var turmasCodigos = new[] { "T1" };
+            var tipoCalendarioId = 1L;
+            var disciplinaId = "D1";
+
+            var query = new ObterFrequenciasAlunoComponentePorTurmasQuery(alunoCodigo, turmasCodigos, tipoCalendarioId, null, 0);
+
+            var frequenciasBimestrais = new List<FrequenciaAluno>
+            {
+                new FrequenciaAluno { DisciplinaId = disciplinaId, TotalAulas = 10, TotalAusencias = 2, TotalCompensacoes = 1, Bimestre = 1 },
+                new FrequenciaAluno { DisciplinaId = disciplinaId, TotalAulas = 12, TotalAusencias = 3, TotalCompensacoes = 0, Bimestre = 2 }
+            };
+
+            var aulasComponentes = new List<TurmaComponenteQntAulasDto>
+            {
+                new TurmaComponenteQntAulasDto { TurmaCodigo = "T1", ComponenteCurricularCodigo = disciplinaId, Bimestre = 1 },
+                new TurmaComponenteQntAulasDto { TurmaCodigo = "T1", ComponenteCurricularCodigo = disciplinaId, Bimestre = 2 }
+            };
+
+            _repositorioFrequenciaMock.Setup(r => r.ObterFrequenciaComponentesAlunoPorTurmas(alunoCodigo, turmasCodigos, tipoCalendarioId, 0))
+                .ReturnsAsync(frequenciasBimestrais);
+            _mediatorMock.Setup(m => m.Send(It.IsAny<ObterBimestresPorTipoCalendarioQuery>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new int[] { 1, 2 });
+            _mediatorMock.Setup(m => m.Send(It.IsAny<ObterTotalAulasTurmaEBimestreEComponenteCurricularQuery>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(aulasComponentes);
+
+            // Act
+            var resultado = await _handler.Handle(query, CancellationToken.None);
+
+            // Assert
+            var freqConsolidada = Assert.Single(resultado);
+            Assert.Equal(disciplinaId, freqConsolidada.DisciplinaId);
+            Assert.Equal(22, freqConsolidada.TotalAulas); // 10 + 12
+            Assert.Equal(5, freqConsolidada.TotalAusencias); // 2 + 3
+            Assert.Equal(1, freqConsolidada.TotalCompensacoes); // 1 + 0
+        }
+    }
+}

--- a/teste/SME.SGP.Aplicacao.Teste/Queries/Frequencia/ObterListaAlunosComAusenciaQueryHandlerTeste.cs
+++ b/teste/SME.SGP.Aplicacao.Teste/Queries/Frequencia/ObterListaAlunosComAusenciaQueryHandlerTeste.cs
@@ -1,0 +1,129 @@
+﻿using Bogus;
+using MediatR;
+using Moq;
+using SME.SGP.Dominio.Interfaces;
+using SME.SGP.Dominio;
+using SME.SGP.Infra;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace SME.SGP.Aplicacao.Teste.Queries.Frequencia
+{
+    public class ObterListaAlunosComAusenciaQueryHandlerTeste
+    {
+        private readonly Mock<IMediator> _mediatorMock;
+        private readonly Mock<IRepositorioFrequenciaAlunoDisciplinaPeriodoConsulta> _repositorioFrequenciaMock;
+        private readonly ObterListaAlunosComAusenciaQueryHandler _handler;
+        private readonly Faker _faker;
+
+        public ObterListaAlunosComAusenciaQueryHandlerTeste()
+        {
+            _mediatorMock = new Mock<IMediator>();
+            _repositorioFrequenciaMock = new Mock<IRepositorioFrequenciaAlunoDisciplinaPeriodoConsulta>();
+            _handler = new ObterListaAlunosComAusenciaQueryHandler(_mediatorMock.Object, _repositorioFrequenciaMock.Object);
+            _faker = new Faker("pt_BR");
+        }
+
+        [Fact(DisplayName = "Deve lançar exceção quando as dependências forem nulas")]
+        public void DeveLancarExcecao_QuandoDependenciasForemNulas()
+        {
+            // Arrange & Act & Assert
+            Assert.Throws<ArgumentNullException>(() => new ObterListaAlunosComAusenciaQueryHandler(null, _repositorioFrequenciaMock.Object));
+            Assert.Throws<ArgumentNullException>(() => new ObterListaAlunosComAusenciaQueryHandler(_mediatorMock.Object, null));
+        }
+
+        [Fact(DisplayName = "Deve retornar a lista de alunos ausentes quando encontrados")]
+        public async Task DeveRetornarListaDeAlunosAusentes_QuandoEncontrados()
+        {
+            // Arrange
+            var query = new ObterListaAlunosComAusenciaQuery("1", "123", 1);
+            var alunoCodigo = "987";
+
+            var turma = new Turma { CodigoTurma = query.TurmaId, AnoLetivo = 2025, ModalidadeCodigo = Modalidade.Fundamental };
+            var periodo = new PeriodoEscolar { Id = 1, Bimestre = 1, PeriodoInicio = DateTime.Now, PeriodoFim = DateTime.Now.AddMonths(2) };
+            var alunosAtivos = new List<AlunoPorTurmaResposta> { new AlunoPorTurmaResposta { CodigoAluno = alunoCodigo, NomeAluno = "Aluno Teste" } };
+            var componentes = new List<DisciplinaDto> { new DisciplinaDto { Id = long.Parse(query.DisciplinaId), Regencia = true } };
+            var frequenciaAluno = CriarFrequenciaAluno(totalAulas: 20, totalAusencias: 5, totalCompensacoes: 1); // 4 faltas não compensadas
+
+            ConfigurarMocks(turma, periodo, alunosAtivos, componentes);
+
+            _repositorioFrequenciaMock.Setup(r => r.ObterPorAlunoDisciplinaPeriodo(alunoCodigo, It.IsAny<string[]>(), periodo.Id, turma.CodigoTurma, It.IsAny<string>()))
+                .Returns(frequenciaAluno);
+
+            // Act
+            var resultado = await _handler.Handle(query, CancellationToken.None);
+
+            // Assert
+            var alunoAusente = Assert.Single(resultado);
+            Assert.Equal(alunoCodigo, alunoAusente.Id);
+            Assert.Equal(4, alunoAusente.QuantidadeFaltasTotais);
+            Assert.Equal(80, alunoAusente.PercentualFrequencia);
+            _mediatorMock.Verify(m => m.Send(It.IsAny<ObterTurmaPorCodigoQuery>(), It.IsAny<CancellationToken>()), Times.Once);
+            _repositorioFrequenciaMock.Verify(r => r.ObterPorAlunoDisciplinaPeriodo(It.IsAny<string>(), It.IsAny<string[]>(), It.IsAny<long>(), It.IsAny<string>(), It.IsAny<string>()), Times.Once);
+        }
+
+        [Fact(DisplayName = "Deve retornar lista vazia quando aluno não possui faltas não compensadas")]
+        public async Task DeveRetornarListaVazia_QuandoAlunoNaoPossuiFaltas()
+        {
+            // Arrange
+            var query = new ObterListaAlunosComAusenciaQuery("1", "123", 1);
+            var alunoCodigo = "987";
+
+            var turma = new Turma { CodigoTurma = query.TurmaId, AnoLetivo = 2025, ModalidadeCodigo = Modalidade.Fundamental };
+            var periodo = new PeriodoEscolar { Id = 1, Bimestre = 1, PeriodoInicio = DateTime.Now, PeriodoFim = DateTime.Now.AddMonths(2) };
+            var alunosAtivos = new List<AlunoPorTurmaResposta> { new AlunoPorTurmaResposta { CodigoAluno = alunoCodigo, NomeAluno = "Aluno Teste" } };
+            var componentes = new List<DisciplinaDto> { new DisciplinaDto { Id = long.Parse(query.DisciplinaId), Regencia = true } };
+            var frequenciaAluno = CriarFrequenciaAluno(totalAulas: 20, totalAusencias: 5, totalCompensacoes: 5); // 0 faltas não compensadas
+
+            ConfigurarMocks(turma, periodo, alunosAtivos, componentes);
+            _repositorioFrequenciaMock.Setup(r => r.ObterPorAlunoDisciplinaPeriodo(alunoCodigo, It.IsAny<string[]>(), periodo.Id, turma.CodigoTurma, It.IsAny<string>()))
+                .Returns(frequenciaAluno);
+
+            // Act
+            var resultado = await _handler.Handle(query, CancellationToken.None);
+
+            // Assert
+            Assert.NotNull(resultado);
+            Assert.Empty(resultado);
+        }
+
+        [Fact(DisplayName = "Deve lançar exceção de negócio quando não encontrar alunos ativos")]
+        public async Task DeveLancarExcecao_QuandoNaoEncontrarAlunosAtivos()
+        {
+            // Arrange
+            var query = new ObterListaAlunosComAusenciaQuery("1", "123", 1);
+
+            var turma = new Turma { CodigoTurma = query.TurmaId, AnoLetivo = 2025, ModalidadeCodigo = Modalidade.Fundamental };
+            var periodo = new PeriodoEscolar { Id = 1, Bimestre = 1, PeriodoInicio = DateTime.Now, PeriodoFim = DateTime.Now.AddMonths(2) };
+
+            ConfigurarMocks(turma, periodo, new List<AlunoPorTurmaResposta>(), new List<DisciplinaDto>());
+
+            // Act & Assert
+            var exception = await Assert.ThrowsAsync<NegocioException>(() => _handler.Handle(query, CancellationToken.None));
+            Assert.Equal("Não foram localizados alunos com matrícula ativa na turma, no período escolar selecionado.", exception.Message);
+        }
+
+        private void ConfigurarMocks(Turma turma, PeriodoEscolar periodo, List<AlunoPorTurmaResposta> alunosAtivos, List<DisciplinaDto> componentes)
+        {
+            _mediatorMock.Setup(m => m.Send(It.IsAny<ObterTurmaPorCodigoQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(turma);
+            _mediatorMock.Setup(m => m.Send(It.IsAny<ObterTipoCalendarioPorAnoLetivoEModalidadeQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(new TipoCalendario());
+            _mediatorMock.Setup(m => m.Send(It.IsAny<ObterPeridosEscolaresPorTipoCalendarioIdQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(new List<PeriodoEscolar> { periodo });
+            _mediatorMock.Setup(m => m.Send(It.IsAny<ObterAlunosDentroPeriodoQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(alunosAtivos);
+            _mediatorMock.Setup(m => m.Send(It.IsAny<ObterComponentesCurricularesPorIdsQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(componentes);
+            _mediatorMock.Setup(m => m.Send(It.IsAny<ObterValorParametroSistemaTipoEAnoQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync("10");
+            _mediatorMock.Setup(m => m.Send(It.IsAny<ObterAlunosAtivosTurmaProgramaPapEolQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(new List<AlunosTurmaProgramaPapDto>());
+        }
+
+        private FrequenciaAluno CriarFrequenciaAluno(int totalAulas, int totalAusencias, int totalCompensacoes) => new FrequenciaAluno
+        {
+            TotalAulas = totalAulas,
+            TotalAusencias = totalAusencias,
+            TotalCompensacoes = totalCompensacoes
+        };
+    }
+}

--- a/teste/SME.SGP.Aplicacao.Teste/Queries/Frequencia/ObterListaFrequenciaAulasQueryHandlerTeste.cs
+++ b/teste/SME.SGP.Aplicacao.Teste/Queries/Frequencia/ObterListaFrequenciaAulasQueryHandlerTeste.cs
@@ -1,0 +1,145 @@
+﻿using Bogus;
+using MediatR;
+using Moq;
+using SME.SGP.Dominio;
+using SME.SGP.Infra;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using System.Threading;
+using System;
+using Xunit;
+using System.Linq;
+
+namespace SME.SGP.Aplicacao.Teste.Queries.Frequencia
+{
+    public class ObterListaFrequenciaAulasQueryHandlerTeste
+    {
+        private readonly Mock<IMediator> _mediatorMock;
+        private readonly ObterListaFrequenciaAulasQueryHandler _handler;
+        private readonly Faker _faker;
+
+        public ObterListaFrequenciaAulasQueryHandlerTeste()
+        {
+            _mediatorMock = new Mock<IMediator>();
+            _handler = new ObterListaFrequenciaAulasQueryHandler(_mediatorMock.Object);
+            _faker = new Faker("pt_BR");
+        }
+
+        [Fact(DisplayName = "Deve lançar exceção quando o mediator for nulo")]
+        public void DeveLancarExcecao_QuandoMediatorNulo()
+        {
+            // Arrange & Act & Assert
+            Assert.Throws<ArgumentNullException>(() => new ObterListaFrequenciaAulasQueryHandler(null));
+        }
+
+        [Fact(DisplayName = "Deve montar o registro de frequência completo quando registra frequência")]
+        public async Task DeveMontarRegistroFrequenciaCompleto_QuandoRegistraFrequencia()
+        {
+            // Arrange
+            var query = CriarQueryFalsa(registraFrequencia: true);
+            var usuario = new Usuario { CodigoRf = "RF123" };
+            usuario.GetType().GetProperty("Perfis").SetValue(usuario, new List<PrioridadePerfil>() { new PrioridadePerfil() { CodigoPerfil = Perfis.PERFIL_PROFESSOR } });
+
+            _mediatorMock.Setup(m => m.Send(It.IsAny<ObterUsuarioLogadoQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(usuario);
+            _mediatorMock.Setup(m => m.Send(It.IsAny<ObterAlunosAtivosTurmaProgramaPapEolQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(new List<AlunosTurmaProgramaPapDto>());
+            _mediatorMock.Setup(m => m.Send(It.IsAny<VerificaEstudantePossuiPlanoAEEPorCodigoEAnoQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(true);
+            _mediatorMock.Setup(m => m.Send(It.IsAny<ObterMarcadorFrequenciaAlunoQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(new MarcadorFrequenciaDto());
+
+            // Act
+            var resultado = await _handler.Handle(query, CancellationToken.None);
+
+            // Assert
+            Assert.NotNull(resultado);
+            Assert.Single(resultado.Aulas);
+            Assert.Single(resultado.Alunos);
+
+            var alunoResultado = Assert.Single(resultado.Alunos);
+            Assert.True(alunoResultado.EhAtendidoAEE);
+            Assert.False(alunoResultado.EhMatriculadoTurmaPAP);
+            Assert.NotNull(alunoResultado.IndicativoFrequencia);
+            Assert.Single(alunoResultado.Aulas);
+
+            _mediatorMock.Verify(m => m.Send(It.IsAny<ObterUsuarioLogadoQuery>(), It.IsAny<CancellationToken>()), Times.Once);
+            _mediatorMock.Verify(m => m.Send(It.IsAny<ObterAlunosAtivosTurmaProgramaPapEolQuery>(), It.IsAny<CancellationToken>()), Times.Once);
+            _mediatorMock.Verify(m => m.Send(It.IsAny<VerificaEstudantePossuiPlanoAEEPorCodigoEAnoQuery>(), It.IsAny<CancellationToken>()), Times.Once);
+            _mediatorMock.Verify(m => m.Send(It.IsAny<ObterMarcadorFrequenciaAlunoQuery>(), It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact(DisplayName = "Deve carregar apenas anotações quando não registra frequência")]
+        public async Task DeveCarregarApenasAnotacoes_QuandoNaoRegistraFrequencia()
+        {
+            // Arrange
+            var query = CriarQueryFalsa(registraFrequencia: false);
+            var usuario = new Usuario { CodigoRf = "RF123" };
+            usuario.GetType().GetProperty("Perfis").SetValue(usuario, new List<PrioridadePerfil>() { new PrioridadePerfil() { CodigoPerfil = Perfis.PERFIL_PROFESSOR } });
+
+            _mediatorMock.Setup(m => m.Send(It.IsAny<ObterUsuarioLogadoQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(usuario);
+            _mediatorMock.Setup(m => m.Send(It.IsAny<ObterAlunosAtivosTurmaProgramaPapEolQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(new List<AlunosTurmaProgramaPapDto>());
+            _mediatorMock.Setup(m => m.Send(It.IsAny<VerificaEstudantePossuiPlanoAEEPorCodigoEAnoQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(false);
+            _mediatorMock.Setup(m => m.Send(It.IsAny<ObterMarcadorFrequenciaAlunoQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(new MarcadorFrequenciaDto());
+
+            // Act
+            var resultado = await _handler.Handle(query, CancellationToken.None);
+
+            // Assert
+            Assert.NotNull(resultado);
+            var alunoResultado = Assert.Single(resultado.Alunos);
+            Assert.Single(alunoResultado.Aulas);
+            Assert.True(alunoResultado.Aulas.First().PossuiAnotacao);
+        }
+
+        [Fact(DisplayName = "Deve retornar nulo quando não houver aulas na requisição")]
+        public async Task DeveRetornarNulo_QuandoNaoHouverAulas()
+        {
+            // Arrange
+            var query = CriarQueryFalsa(comAulas: false);
+            var usuario = new Usuario { CodigoRf = "RF123" };
+            usuario.GetType().GetProperty("Perfis").SetValue(usuario, new List<PrioridadePerfil>() { new PrioridadePerfil() { CodigoPerfil = Perfis.PERFIL_PROFESSOR } });
+
+            _mediatorMock.Setup(m => m.Send(It.IsAny<ObterUsuarioLogadoQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(usuario);
+
+            // Act
+            var resultado = await _handler.Handle(query, CancellationToken.None);
+
+            // Assert
+            Assert.Null(resultado);
+        }
+
+        private ObterListaFrequenciaAulasQuery CriarQueryFalsa(bool registraFrequencia = true, bool comAulas = true)
+        {
+            var alunoCodigo = _faker.Random.AlphaNumeric(8);
+            var turmaCodigo = _faker.Random.Number(1000, 9999).ToString();
+            var aulaId = _faker.Random.Long(1);
+
+            var filtro = new FiltroFrequenciaAulasDto
+            {
+                Turma = new Turma { CodigoTurma = turmaCodigo, AnoLetivo = DateTime.Now.Year, ModalidadeCodigo = Modalidade.Fundamental },
+                AlunosDaTurma = new List<AlunoPorTurmaResposta>
+                {
+                    new AlunoPorTurmaResposta { CodigoAluno = alunoCodigo, NomeAluno = _faker.Name.FullName() }
+                },
+                Aulas = comAulas ? new List<Aula>
+                {
+                    new Aula { Id = aulaId, TurmaId = turmaCodigo, DataAula = DateTime.Now }
+                } : new List<Aula>(),
+                FrequenciaAlunos = new List<FrequenciaAluno>
+                {
+                    new FrequenciaAluno { CodigoAluno = alunoCodigo, TotalAulas = 10, TotalAusencias = 2 }
+                },
+                RegistrosFrequenciaAlunos = new List<RegistroFrequenciaAlunoPorAulaDto>
+                {
+                    new RegistroFrequenciaAlunoPorAulaDto { AlunoCodigo = alunoCodigo, AulaId = aulaId, NumeroAula = 1, TipoFrequencia = TipoFrequencia.F }
+                },
+                AnotacoesTurma = new List<AnotacaoAlunoAulaDto>
+                {
+                    new AnotacaoAlunoAulaDto { AlunoCodigo = alunoCodigo, AulaId = aulaId }
+                },
+                CompensacaoAusenciaAlunoAulas = new List<CompensacaoAusenciaAlunoAulaSimplificadoDto>(),
+                FrequenciasPreDefinidas = new List<FrequenciaPreDefinidaDto>(),
+                RegistraFrequencia = registraFrequencia
+            };
+
+            return new ObterListaFrequenciaAulasQuery(filtro);
+        }
+    }
+}

--- a/teste/SME.SGP.Aplicacao.Teste/Queries/Frequencia/ObterMarcadorFrequenciaAlunoQueryHandlerTeste.cs
+++ b/teste/SME.SGP.Aplicacao.Teste/Queries/Frequencia/ObterMarcadorFrequenciaAlunoQueryHandlerTeste.cs
@@ -1,0 +1,149 @@
+﻿using SME.SGP.Aplicacao.Queries.Frequencia.ObterMarcadorFrequenciaAluno;
+using SME.SGP.Dominio;
+using SME.SGP.Infra;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace SME.SGP.Aplicacao.Teste.Queries.Frequencia
+{
+    public class ObterMarcadorFrequenciaAlunoQueryHandlerTeste
+    {
+        private readonly ObterMarcadorFrequenciaAlunoQueryHandler _handler;
+
+        public ObterMarcadorFrequenciaAlunoQueryHandlerTeste()
+        {
+            _handler = new ObterMarcadorFrequenciaAlunoQueryHandler();
+        }
+
+        [Fact(DisplayName = "Deve retornar marcador 'Novo' para aluno ativo dentro do período de 15 dias")]
+        public async Task Handle_QuandoAlunoAtivoRecente_DeveRetornarMarcadorNovo()
+        {
+            // Arrange
+            var hoje = DateTime.Now.Date;
+            var periodoEscolar = new PeriodoEscolar { PeriodoInicio = hoje.AddDays(-20) };
+            var aluno = new AlunoPorTurmaResposta
+            {
+                CodigoSituacaoMatricula = SituacaoMatriculaAluno.Ativo,
+                DataSituacao = hoje.AddDays(-5) // Matrícula há 5 dias
+            };
+            var query = new ObterMarcadorFrequenciaAlunoQuery(aluno, periodoEscolar, Modalidade.Fundamental);
+
+            // Act
+            var resultado = await _handler.Handle(query, CancellationToken.None);
+
+            // Assert
+            Assert.NotNull(resultado);
+            Assert.Equal(TipoMarcadorFrequencia.Novo, resultado.Tipo);
+            Assert.Contains("Estudante Novo", resultado.Descricao);
+        }
+
+        [Fact(DisplayName = "Não deve retornar marcador 'Novo' para aluno ativo há mais de 15 dias")]
+        public async Task Handle_QuandoAlunoAtivoAntigo_NaoDeveRetornarMarcador()
+        {
+            // Arrange
+            var hoje = DateTime.Now.Date;
+            var periodoEscolar = new PeriodoEscolar { PeriodoInicio = hoje.AddDays(-30) };
+            var aluno = new AlunoPorTurmaResposta
+            {
+                CodigoSituacaoMatricula = SituacaoMatriculaAluno.Ativo,
+                DataSituacao = hoje.AddDays(-20) // Matrícula há 20 dias
+            };
+            var query = new ObterMarcadorFrequenciaAlunoQuery(aluno, periodoEscolar, Modalidade.Fundamental);
+
+            // Act
+            var resultado = await _handler.Handle(query, CancellationToken.None);
+
+            // Assert
+            Assert.Null(resultado);
+        }
+
+        [Fact(DisplayName = "Deve retornar marcador 'Transferido' para aluno transferido")]
+        public async Task Handle_QuandoAlunoTransferido_DeveRetornarMarcadorTransferido()
+        {
+            // Arrange
+            var aluno = new AlunoPorTurmaResposta
+            {
+                CodigoSituacaoMatricula = SituacaoMatriculaAluno.Transferido,
+                DataSituacao = DateTime.Now.Date,
+                Transferencia_Interna = true,
+                EscolaTransferencia = "EMEF TESTE",
+                TurmaTransferencia = "9A"
+            };
+            var query = new ObterMarcadorFrequenciaAlunoQuery(aluno, new PeriodoEscolar(), Modalidade.EducacaoInfantil);
+
+            // Act
+            var resultado = await _handler.Handle(query, CancellationToken.None);
+
+            // Assert
+            Assert.NotNull(resultado);
+            Assert.Equal(TipoMarcadorFrequencia.Transferido, resultado.Tipo);
+            Assert.Contains("Criança Transferida", resultado.Descricao);
+            Assert.Contains("para escola EMEF TESTE e turma 9A", resultado.Descricao);
+        }
+
+        [Fact(DisplayName = "Deve retornar marcador 'Remanejado' para aluno remanejado")]
+        public async Task Handle_QuandoAlunoRemanejado_DeveRetornarMarcadorRemanejado()
+        {
+            // Arrange
+            var aluno = new AlunoPorTurmaResposta
+            {
+                CodigoSituacaoMatricula = SituacaoMatriculaAluno.RemanejadoSaida,
+                DataSituacao = DateTime.Now.Date,
+                TurmaRemanejamento = "8B"
+            };
+            var query = new ObterMarcadorFrequenciaAlunoQuery(aluno, new PeriodoEscolar(), Modalidade.Fundamental);
+
+            // Act
+            var resultado = await _handler.Handle(query, CancellationToken.None);
+
+            // Assert
+            Assert.NotNull(resultado);
+            Assert.Equal(TipoMarcadorFrequencia.Remanejado, resultado.Tipo);
+            Assert.Contains("Estudante Remanejado", resultado.Descricao);
+            Assert.Contains("turma 8B", resultado.Descricao);
+        }
+
+        [Theory(DisplayName = "Deve retornar marcador 'Inativo' para diversas situações de inatividade")]
+        [InlineData(SituacaoMatriculaAluno.Desistente)]
+        [InlineData(SituacaoMatriculaAluno.VinculoIndevido)]
+        [InlineData(SituacaoMatriculaAluno.Falecido)]
+        [InlineData(SituacaoMatriculaAluno.NaoCompareceu)]
+        [InlineData(SituacaoMatriculaAluno.Deslocamento)]
+        [InlineData(SituacaoMatriculaAluno.Cessado)]
+        [InlineData(SituacaoMatriculaAluno.ReclassificadoSaida)]
+        public async Task Handle_QuandoAlunoInativo_DeveRetornarMarcadorInativo(SituacaoMatriculaAluno situacao)
+        {
+            // Arrange
+            var aluno = new AlunoPorTurmaResposta
+            {
+                CodigoSituacaoMatricula = situacao,
+                DataSituacao = DateTime.Now.Date
+            };
+            var query = new ObterMarcadorFrequenciaAlunoQuery(aluno, new PeriodoEscolar(), Modalidade.Fundamental);
+
+            // Act
+            var resultado = await _handler.Handle(query, CancellationToken.None);
+
+            // Assert
+            Assert.NotNull(resultado);
+            Assert.Equal(TipoMarcadorFrequencia.Inativo, resultado.Tipo);
+            Assert.Contains("Estudante Inativo", resultado.Descricao);
+        }
+
+        [Fact(DisplayName = "Não deve retornar marcador para situações não mapeadas")]
+        public async Task Handle_QuandoSituacaoNaoMapeada_NaoDeveRetornarMarcador()
+        {
+            // Arrange
+            var aluno = new AlunoPorTurmaResposta { CodigoSituacaoMatricula = SituacaoMatriculaAluno.Concluido };
+            var query = new ObterMarcadorFrequenciaAlunoQuery(aluno, new PeriodoEscolar(), Modalidade.Fundamental);
+
+            // Act
+            var resultado = await _handler.Handle(query, CancellationToken.None);
+
+            // Assert
+            Assert.Null(resultado);
+        }
+    }
+}

--- a/teste/SME.SGP.Aplicacao.Teste/Queries/Frequencia/ObterRegistroFrequenciaAlunosPorAlunosETurmaIdQueryHandlerTeste.cs
+++ b/teste/SME.SGP.Aplicacao.Teste/Queries/Frequencia/ObterRegistroFrequenciaAlunosPorAlunosETurmaIdQueryHandlerTeste.cs
@@ -1,0 +1,105 @@
+﻿using Bogus;
+using Moq;
+using SME.SGP.Dominio.Constantes;
+using SME.SGP.Dominio.Interfaces;
+using SME.SGP.Infra;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Newtonsoft.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace SME.SGP.Aplicacao.Teste.Queries.Frequencia
+{
+    public class ObterRegistroFrequenciaAlunosPorAlunosETurmaIdQueryHandlerTeste
+    {
+        private readonly Mock<IRepositorioRegistroFrequenciaAlunoConsulta> _repositorioFrequenciaAlunoMock;
+        private readonly Mock<IRepositorioCache> _repositorioCacheMock;
+        private readonly ObterRegistroFrequenciaAlunosPorAlunosETurmaIdQueryHandler _handler;
+
+        public ObterRegistroFrequenciaAlunosPorAlunosETurmaIdQueryHandlerTeste()
+        {
+            _repositorioFrequenciaAlunoMock = new Mock<IRepositorioRegistroFrequenciaAlunoConsulta>();
+            _repositorioCacheMock = new Mock<IRepositorioCache>();
+            _handler = new ObterRegistroFrequenciaAlunosPorAlunosETurmaIdQueryHandler(
+                _repositorioFrequenciaAlunoMock.Object,
+                _repositorioCacheMock.Object);
+        }
+
+        [Fact(DisplayName = "Deve lançar exceção quando as dependências forem nulas")]
+        public void DeveLancarExcecao_QuandoDependenciasForemNulas()
+        {
+            // Arrange & Act & Assert
+            Assert.Throws<ArgumentNullException>(() => new ObterRegistroFrequenciaAlunosPorAlunosETurmaIdQueryHandler(null, _repositorioCacheMock.Object));
+            Assert.Throws<ArgumentNullException>(() => new ObterRegistroFrequenciaAlunosPorAlunosETurmaIdQueryHandler(_repositorioFrequenciaAlunoMock.Object, null));
+        }
+
+        [Fact(DisplayName = "Deve chamar repositório com Ids desconsiderados vazios quando não houver dados no cache")]
+        public async Task DeveChamarRepositorio_ComIdsDesconsideradosVazios_QuandoCacheVazio()
+        {
+            // Arrange
+            var turmasId = new[] { "100", "200" };
+            var query = new ObterRegistroFrequenciaAlunosPorAlunosETurmaIdQuery(DateTime.Now, new[] { "ALUNO1" }, "PROF1", turmasId);
+            var retornoEsperado = new List<RegistroFrequenciaPorDisciplinaAlunoDto>();
+
+            _repositorioCacheMock.Setup(r => r.ObterAsync(It.IsAny<string>(), false)).ReturnsAsync((string)null);
+
+            _repositorioFrequenciaAlunoMock
+                .Setup(r => r.ObterRegistroFrequenciaAlunosPorAlunosETurmaIdEDataAula(
+                    query.DataAula,
+                    query.TurmasId,
+                    query.Alunos,
+                    query.Professor,
+                    It.Is<long[]>(ids => !ids.Any()))) // Verifica se o array está vazio
+                .ReturnsAsync(retornoEsperado);
+
+            // Act
+            var resultado = await _handler.Handle(query, CancellationToken.None);
+
+            // Assert
+            Assert.Same(retornoEsperado, resultado);
+            _repositorioCacheMock.Verify(r => r.ObterAsync(It.IsAny<string>(), false), Times.Exactly(turmasId.Length));
+            _repositorioFrequenciaAlunoMock.Verify(r => r.ObterRegistroFrequenciaAlunosPorAlunosETurmaIdEDataAula(
+                query.DataAula, query.TurmasId, query.Alunos, query.Professor, It.Is<long[]>(ids => !ids.Any())), Times.Once);
+        }
+
+        [Fact(DisplayName = "Deve chamar repositório com Ids desconsiderados do cache quando houver dados")]
+        public async Task DeveChamarRepositorio_ComIdsDesconsideradosDoCache_QuandoCacheContemDados()
+        {
+            // Arrange
+            var turmasId = new[] { "100", "200" };
+            var query = new ObterRegistroFrequenciaAlunosPorAlunosETurmaIdQuery(DateTime.Now, new[] { "ALUNO1" }, "PROF1", turmasId);
+            var retornoEsperado = new List<RegistroFrequenciaPorDisciplinaAlunoDto>();
+
+            var idsDesconsideradosTurma1 = new long[] { 1, 2, 3 };
+            var idsDesconsideradosTurma2 = new long[] { 4, 5 };
+            var idsAgregadosEsperados = new long[] { 1, 2, 3, 4, 5 };
+
+            var chaveCacheTurma1 = string.Format(NomeChaveCache.REGISTROS_FREQUENCIA_ALUNO_EXCLUIDOS_TURMA, turmasId[0]);
+            var chaveCacheTurma2 = string.Format(NomeChaveCache.REGISTROS_FREQUENCIA_ALUNO_EXCLUIDOS_TURMA, turmasId[1]);
+
+            _repositorioCacheMock.Setup(r => r.ObterAsync(chaveCacheTurma1, false)).ReturnsAsync(JsonConvert.SerializeObject(idsDesconsideradosTurma1));
+            _repositorioCacheMock.Setup(r => r.ObterAsync(chaveCacheTurma2, false)).ReturnsAsync(JsonConvert.SerializeObject(idsDesconsideradosTurma2));
+
+            _repositorioFrequenciaAlunoMock
+                .Setup(r => r.ObterRegistroFrequenciaAlunosPorAlunosETurmaIdEDataAula(
+                    query.DataAula,
+                    query.TurmasId,
+                    query.Alunos,
+                    query.Professor,
+                    It.Is<long[]>(ids => ids.SequenceEqual(idsAgregadosEsperados))))
+                .ReturnsAsync(retornoEsperado);
+
+            // Act
+            var resultado = await _handler.Handle(query, CancellationToken.None);
+
+            // Assert
+            Assert.Same(retornoEsperado, resultado);
+            _repositorioCacheMock.Verify(r => r.ObterAsync(It.IsAny<string>(), false), Times.Exactly(turmasId.Length));
+            _repositorioFrequenciaAlunoMock.Verify(r => r.ObterRegistroFrequenciaAlunosPorAlunosETurmaIdEDataAula(
+                query.DataAula, query.TurmasId, query.Alunos, query.Professor, It.Is<long[]>(ids => ids.SequenceEqual(idsAgregadosEsperados))), Times.Once);
+        }
+    }
+}


### PR DESCRIPTION
Implemented unit tests for various controllers and query handlers in the SME.SGP.Api and SME.SGP.Aplicacao namespaces. Utilized Moq for mocking dependencies and Bogus for generating fake data. Tests cover functionalities such as saving, retrieving, and deleting student records, along with handling scenarios like empty uploads and invalid data. Ensured correct method calls on mocked use cases and validation of input data.