### PR TITLE
Add unit tests for frequency query handlers

### DIFF
--- a/teste/SME.SGP.Aplicacao.Teste/Queries/Frequencia/ExigeAprovacaoDeNotaQueryHandlerTeste.cs
+++ b/teste/SME.SGP.Aplicacao.Teste/Queries/Frequencia/ExigeAprovacaoDeNotaQueryHandlerTeste.cs
@@ -1,0 +1,130 @@
+﻿using Bogus;
+using MediatR;
+using Moq;
+using SME.SGP.Dominio;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace SME.SGP.Aplicacao.Teste.Queries.Frequencia
+{
+    public class ExigeAprovacaoDeNotaQueryHandlerTeste
+    {
+        private readonly Faker _faker;
+        private readonly Mock<IMediator> _mediatorMock;
+        private readonly ExigeAprovacaoDeNotaQueryHandler _handler;
+
+        public ExigeAprovacaoDeNotaQueryHandlerTeste()
+        {
+            _faker = new Faker();
+            _mediatorMock = new Mock<IMediator>();
+            _handler = new ExigeAprovacaoDeNotaQueryHandler(_mediatorMock.Object);
+        }
+
+        [Fact]
+        public void DeveLancarExcecao_QuandoMediatorNulo()
+        {
+            // Arrange & Act & Assert
+            Assert.Throws<ArgumentNullException>(() => new ExigeAprovacaoDeNotaQueryHandler(null));
+        }
+
+        [Fact(DisplayName = "Deve retornar true quando ano letivo da turma não é o atual o usuário não é gestor escolar e parametro AprovacaoAlteracaoNotaFechamento")]
+        public async Task DeveChamarMediator_E_RetornarExigeAprovacaoDeNota()
+        {
+            // Arrange
+            var anoAnterior = DateTime.Today.Year - 1;
+            var turma = new Turma { AnoLetivo = _faker.Random.Int(2000, anoAnterior) };
+            var query = new ExigeAprovacaoDeNotaQuery(turma);
+            _mediatorMock
+                .Setup(m => m.Send(It.IsAny<ObterUsuarioLogadoQuery>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new Usuario { PerfilAtual = Perfis.PERFIL_COORDENADOR_NAAPA });
+            _mediatorMock
+                .Setup(m => m.Send(It.IsAny<ObterParametroSistemaPorTipoEAnoQuery>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ParametrosSistema { Ativo = true });
+            // Act
+            var resultado = await _handler.Handle(query, CancellationToken.None);
+
+            // Assert
+            Assert.True(resultado);
+        }
+
+        [Theory(DisplayName = "Deve retornar false quando o usuário é gestor")]
+        [InlineData("44E1E074-37D6-E911-ABD6-F81654FE895D" /*PERFIL_CP*/)]
+        [InlineData("32C01A4F-B251-4A0F-933D-5B61C8B5DDBF" /*PERFIL_COORDENADOR_CELP*/)]
+        [InlineData("46E1E074-37D6-E911-ABD6-F81654FE895D" /*PERFIL_DIRETOR*/)]
+        [InlineData("45E1E074-37D6-E911-ABD6-F81654FE895D" /*PERFIL_AD*/)]
+        public async Task DeveChamarMediator_E_RetornarExigeAprovacaoDeNota_False_QuandoUsuarioEhGestor(string perfil)
+        {
+            // Arrange
+            var anoAtual = DateTime.Today.Year;
+            var turma = new Turma { AnoLetivo = _faker.Random.Int(anoAtual, anoAtual + 5) };
+            var query = new ExigeAprovacaoDeNotaQuery(turma);
+            _mediatorMock
+                .Setup(m => m.Send(It.IsAny<ObterUsuarioLogadoQuery>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new Usuario { PerfilAtual = Guid.Parse(perfil) });
+            _mediatorMock
+                .Setup(m => m.Send(It.IsAny<ObterParametroSistemaPorTipoEAnoQuery>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ParametrosSistema { Ativo = true });
+            // Act
+            var resultado = await _handler.Handle(query, CancellationToken.None);
+            // Assert
+            Assert.False(resultado);
+        }
+
+        [Fact(DisplayName = "Deve retornar false quando AprovacaoAlteracaoNotaFechamento estiver inativo")]
+        public async Task DeveChamarMediator_E_RetornarExigeAprovacaoDeNota_False_QuandoParametroInativo()
+        {
+            // Arrange
+            var anoAnterior = DateTime.Today.Year - 1;
+            var turma = new Turma { AnoLetivo = _faker.Random.Int(2000, anoAnterior) };
+            var query = new ExigeAprovacaoDeNotaQuery(turma);
+            _mediatorMock
+                .Setup(m => m.Send(It.IsAny<ObterUsuarioLogadoQuery>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new Usuario { PerfilAtual = Perfis.PERFIL_POSL });
+            _mediatorMock
+                .Setup(m => m.Send(It.IsAny<ObterParametroSistemaPorTipoEAnoQuery>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ParametrosSistema { Ativo = false });
+            // Act
+            var resultado = await _handler.Handle(query, CancellationToken.None);
+            // Assert
+            Assert.False(resultado);
+        }
+
+        [Fact(DisplayName = "Deve lançar exceção quando parametro aprovação não for encontrado")]
+        public async Task DeveLancarExcecao_QuandoParametroAprovacaoNaoEncontrado()
+        {
+            // Arrange
+            var anoAnterior = DateTime.Today.Year - 1;
+            var turma = new Turma { AnoLetivo = _faker.Random.Int(2000, anoAnterior) };
+            var query = new ExigeAprovacaoDeNotaQuery(turma);
+            _mediatorMock
+                .Setup(m => m.Send(It.IsAny<ObterUsuarioLogadoQuery>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new Usuario { PerfilAtual = Perfis.PERFIL_PROFESSOR });
+            _mediatorMock
+                .Setup(m => m.Send(It.IsAny<ObterParametroSistemaPorTipoEAnoQuery>(), It.IsAny<CancellationToken>()))
+                .Throws(new NegocioException($"Não foi possível localizar o parametro 'AprovacaoAlteracaoNotafechamento' para o ano {turma.AnoLetivo}"));
+            // Act & Assert
+            await Assert.ThrowsAsync<NegocioException>(() => _handler.Handle(query, CancellationToken.None));
+        }
+
+        [Fact(DisplayName = "Deve retornar false quando ano letivo da turma é o atual")]
+        public async Task DeveChamarMediator_E_RetornarExigeAprovacaoDeNota_False_QuandoAnoLetivoAtual()
+        {
+            // Arrange
+            var anoAtual = DateTime.Today.Year;
+            var turma = new Turma { AnoLetivo = anoAtual };
+            var query = new ExigeAprovacaoDeNotaQuery(turma);
+            _mediatorMock
+                .Setup(m => m.Send(It.IsAny<ObterUsuarioLogadoQuery>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new Usuario { PerfilAtual = Perfis.PERFIL_PROFESSOR });
+            _mediatorMock
+                .Setup(m => m.Send(It.IsAny<ObterParametroSistemaPorTipoEAnoQuery>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ParametrosSistema { Ativo = true });
+            // Act
+            var resultado = await _handler.Handle(query, CancellationToken.None);
+            // Assert
+            Assert.False(resultado);
+        }
+    }
+}

--- a/teste/SME.SGP.Aplicacao.Teste/Queries/Frequencia/ExisteFrequenciaRegistradaPorTurmaComponenteCurricularEBimestresQueryHandlerTeste.cs
+++ b/teste/SME.SGP.Aplicacao.Teste/Queries/Frequencia/ExisteFrequenciaRegistradaPorTurmaComponenteCurricularEBimestresQueryHandlerTeste.cs
@@ -1,0 +1,65 @@
+﻿using Bogus;
+using Moq;
+using SME.SGP.Dominio.Interfaces;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace SME.SGP.Aplicacao.Teste.Queries.Frequencia
+{
+    public class ExisteFrequenciaRegistradaPorTurmaComponenteCurricularEBimestresQueryHandlerTeste
+    {
+        private readonly Mock<IRepositorioFrequenciaAlunoDisciplinaPeriodoConsulta> _repositorioFrequenciaMock;
+        private readonly ExisteFrequenciaRegistradaPorTurmaComponenteCurricularEBimestresQueryHandler _handler;
+        private readonly Faker _faker;
+
+        public ExisteFrequenciaRegistradaPorTurmaComponenteCurricularEBimestresQueryHandlerTeste()
+        {
+            _repositorioFrequenciaMock = new Mock<IRepositorioFrequenciaAlunoDisciplinaPeriodoConsulta>();
+            _handler = new ExisteFrequenciaRegistradaPorTurmaComponenteCurricularEBimestresQueryHandler(_repositorioFrequenciaMock.Object);
+            _faker = new Faker("pt_BR");
+        }
+
+        [Fact(DisplayName = "Deve lançar exceção quando o repositório for nulo")]
+        public void DeveLancarExcecao_QuandoRepositorioNulo()
+        {
+            // Arrange & Act & Assert
+            Assert.Throws<ArgumentNullException>(() => new ExisteFrequenciaRegistradaPorTurmaComponenteCurricularEBimestresQueryHandler(null));
+        }
+
+        [Theory(DisplayName = "Deve chamar o repositório e retornar o valor de existência de frequência")]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task DeveChamarRepositorio_E_RetornarExistenciaDeFrequencia(bool retornoEsperado)
+        {
+            // Arrange
+            var query = new ExisteFrequenciaRegistradaPorTurmaComponenteCurricularEBimestresQuery(
+                _faker.Random.AlphaNumeric(5),
+                new[] { _faker.Random.Long(1).ToString() },
+                new[] { _faker.Random.Long(1) },
+                _faker.Random.AlphaNumeric(7)
+            );
+
+            _repositorioFrequenciaMock
+                .Setup(r => r.ExisteFrequenciaRegistradaPorTurmaComponenteCurricularEBimestres(
+                    query.CodigoTurma,
+                    query.ComponentesCurricularesId,
+                    query.PeriodosEscolaresIds,
+                    query.Professor))
+                .ReturnsAsync(retornoEsperado);
+
+            // Act
+            var resultado = await _handler.Handle(query, CancellationToken.None);
+
+            // Assert
+            _repositorioFrequenciaMock.Verify(r => r.ExisteFrequenciaRegistradaPorTurmaComponenteCurricularEBimestres(
+                query.CodigoTurma,
+                query.ComponentesCurricularesId,
+                query.PeriodosEscolaresIds,
+                query.Professor), Times.Once);
+
+            Assert.Equal(retornoEsperado, resultado);
+        }
+    }
+}

--- a/teste/SME.SGP.Aplicacao.Teste/Queries/Frequencia/ExisteFrequenciaRegistradaPorTurmaComponenteCurricularQueryHandlerTeste.cs
+++ b/teste/SME.SGP.Aplicacao.Teste/Queries/Frequencia/ExisteFrequenciaRegistradaPorTurmaComponenteCurricularQueryHandlerTeste.cs
@@ -1,0 +1,58 @@
+﻿using Bogus;
+using Moq;
+using SME.SGP.Dominio.Interfaces;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace SME.SGP.Aplicacao.Teste.Queries.Frequencia
+{
+    public class ExisteFrequenciaRegistradaPorTurmaComponenteCurricularQueryHandlerTeste
+    {
+        private readonly Faker _faker;
+        private readonly Mock<IRepositorioFrequenciaAlunoDisciplinaPeriodoConsulta> _repositorioFrequenciaMock;
+        private readonly ExisteFrequenciaRegistradaPorTurmaComponenteCurricularQueryHandler _handler;
+
+        public ExisteFrequenciaRegistradaPorTurmaComponenteCurricularQueryHandlerTeste()
+        {
+            _faker = new Faker();
+            _repositorioFrequenciaMock = new Mock<IRepositorioFrequenciaAlunoDisciplinaPeriodoConsulta>();
+            _handler = new ExisteFrequenciaRegistradaPorTurmaComponenteCurricularQueryHandler(_repositorioFrequenciaMock.Object);
+        }
+
+        [Fact(DisplayName = "Deve lançar exceção quando o repositório for nulo")]
+        public void DeveLancarExcecao_QuandoRepositorioNulo()
+        {
+            // Arrange & Act & Assert
+            Assert.Throws<ArgumentNullException>(() => new ExisteFrequenciaRegistradaPorTurmaComponenteCurricularQueryHandler(null));
+        }
+
+        [Fact(DisplayName = "Deve chamar o repositório e retornar o valor de existência de frequência")]
+        public async Task DeveChamarRepositorio_E_RetornarExistenciaDeFrequencia()
+        {
+            // Arrange      
+            var query = new ExisteFrequenciaRegistradaPorTurmaComponenteCurricularQuery(
+                _faker.Random.AlphaNumeric(5),
+                new[] { _faker.Random.Long(1).ToString() },
+                _faker.Random.Long(1)
+            );
+
+            var retornoEsperado = _faker.Random.Bool();
+            _repositorioFrequenciaMock
+                .Setup(r => r.ExisteFrequenciaRegistradaPorTurmaComponenteCurricular(It.IsAny<string>(), It.IsAny<string[]>(), It.IsAny<long>(), It.IsAny<string>()))
+                .ReturnsAsync(retornoEsperado);
+
+            // Act
+            var resultado = await _handler.Handle(query, CancellationToken.None);
+
+            // Assert
+            Assert.NotNull(resultado);
+            Assert.Equal(retornoEsperado, resultado);
+            _repositorioFrequenciaMock.Verify(r => r.ExisteFrequenciaRegistradaPorTurmaComponenteCurricular(
+                query.CodigoTurma,
+                query.ComponentesCurricularesId,
+                query.PeriodoEscolarId, It.IsAny<string>()), Times.Once);
+        }
+    }
+}

--- a/teste/SME.SGP.Aplicacao.Teste/Queries/Frequencia/ObterAlunosAusentesPorTurmaNoPeriodoQueryHandlerTeste.cs
+++ b/teste/SME.SGP.Aplicacao.Teste/Queries/Frequencia/ObterAlunosAusentesPorTurmaNoPeriodoQueryHandlerTeste.cs
@@ -1,0 +1,65 @@
+﻿using Bogus;
+using Moq;
+using SME.SGP.Dominio.Interfaces;
+using SME.SGP.Infra;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace SME.SGP.Aplicacao.Teste.Queries.Frequencia
+{
+    public class ObterAlunosAusentesPorTurmaNoPeriodoQueryHandlerTeste
+    {
+        private readonly Mock<IRepositorioFrequenciaConsulta> _repositorioFrequenciaMock;
+        private readonly ObterAlunosAusentesPorTurmaNoPeriodoQueryHandler _handler;
+        private readonly Faker _faker;
+
+        public ObterAlunosAusentesPorTurmaNoPeriodoQueryHandlerTeste()
+        {
+            _repositorioFrequenciaMock = new Mock<IRepositorioFrequenciaConsulta>();
+            _handler = new ObterAlunosAusentesPorTurmaNoPeriodoQueryHandler(_repositorioFrequenciaMock.Object);
+            _faker = new Faker("pt_BR");
+        }
+
+        [Fact(DisplayName = "Deve lançar exceção quando o repositório for nulo")]
+        public void DeveLancarExcecao_QuandoRepositorioNulo()
+        {
+            // Arrange & Act & Assert
+            Assert.Throws<ArgumentNullException>(() => new ObterAlunosAusentesPorTurmaNoPeriodoQueryHandler(null));
+        }
+
+        [Fact(DisplayName = "Deve chamar o repositório para obter alunos ausentes e retornar os dados")]
+        public async Task DeveChamarRepositorio_E_RetornarAlunosAusentes()
+        {
+            // Arrange
+            var turmaCodigo = _faker.Random.AlphaNumeric(5);
+            var dataInicio = DateTime.Now.Date;
+            var dataFim = dataInicio.AddDays(15);
+            var componenteId = _faker.Random.Long(1, 1000).ToString();
+
+            var query = new ObterAlunosAusentesPorTurmaNoPeriodoQuery(turmaCodigo, dataInicio, dataFim, componenteId);
+
+            var retornoRepositorio = new List<AlunoComponenteCurricularDto>
+            {
+                new AlunoComponenteCurricularDto
+                {
+                    AlunoCodigo = _faker.Random.AlphaNumeric(8),
+                    ComponenteCurricularId = componenteId
+                }
+            };
+
+            _repositorioFrequenciaMock
+                .Setup(r => r.ObterAlunosAusentesPorTurmaEPeriodo(turmaCodigo, dataInicio, dataFim, componenteId))
+                .ReturnsAsync(retornoRepositorio);
+
+            // Act
+            var resultado = await _handler.Handle(query, CancellationToken.None);
+
+            // Assert
+            _repositorioFrequenciaMock.Verify(r => r.ObterAlunosAusentesPorTurmaEPeriodo(turmaCodigo, dataInicio, dataFim, componenteId), Times.Once);
+            Assert.Same(retornoRepositorio, resultado);
+        }
+    }
+}

--- a/teste/SME.SGP.Aplicacao.Teste/Queries/Frequencia/ObterAulaPossuiFrequenciaQueryHandlerTeste.cs
+++ b/teste/SME.SGP.Aplicacao.Teste/Queries/Frequencia/ObterAulaPossuiFrequenciaQueryHandlerTeste.cs
@@ -1,0 +1,50 @@
+﻿using Bogus;
+using Moq;
+using SME.SGP.Dominio.Interfaces;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace SME.SGP.Aplicacao.Teste.Queries.Frequencia
+{
+    public class ObterAulaPossuiFrequenciaQueryHandlerTeste
+    {
+        private readonly Faker _faker;
+        private readonly Mock<IRepositorioFrequenciaConsulta> _repositorioFrequenciaMock;
+        private readonly ObterAulaPossuiFrequenciaQueryHandler _handler;
+
+        public ObterAulaPossuiFrequenciaQueryHandlerTeste()
+        {
+            _faker = new Faker();
+            _repositorioFrequenciaMock = new Mock<IRepositorioFrequenciaConsulta>();
+            _handler = new ObterAulaPossuiFrequenciaQueryHandler(_repositorioFrequenciaMock.Object);
+        }
+
+        [Fact]
+        public void DeveLancarExcecao_QuandoRepositorioNulo()
+        {
+            // Arrange & Act & Assert
+            Assert.Throws<ArgumentNullException>(() => new ObterAulaPossuiFrequenciaQueryHandler(null));
+        }
+
+        [Fact]
+        public async Task DeveChamarRepositorio_E_RetornarFrequenciaAulaRegistrada()
+        {
+            // Arrange
+            var aulaId = _faker.Random.Long(1);
+            var query = new ObterAulaPossuiFrequenciaQuery(aulaId);
+            var retornoEsperado = _faker.Random.Bool();
+            _repositorioFrequenciaMock
+                .Setup(r => r.FrequenciaAulaRegistrada(aulaId))
+                .ReturnsAsync(retornoEsperado);
+
+            // Act
+            var resultado = await _handler.Handle(query, CancellationToken.None);
+
+            // Assert
+            Assert.Equal(retornoEsperado, resultado);
+            _repositorioFrequenciaMock.Verify(r => r.FrequenciaAulaRegistrada(aulaId), Times.Once);
+        }
+    }
+}

--- a/teste/SME.SGP.Aplicacao.Teste/Queries/Frequencia/ObterAulasComFrequenciaPorTurmaCodigoQueryHandlerTeste.cs
+++ b/teste/SME.SGP.Aplicacao.Teste/Queries/Frequencia/ObterAulasComFrequenciaPorTurmaCodigoQueryHandlerTeste.cs
@@ -1,0 +1,64 @@
+﻿using Bogus;
+using Moq;
+using SME.SGP.Dominio.Interfaces;
+using SME.SGP.Infra.Dtos;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace SME.SGP.Aplicacao.Teste.Queries.Frequencia
+{
+    public class ObterAulasComFrequenciaPorTurmaCodigoQueryHandlerTeste
+    {
+        private readonly Mock<IRepositorioFrequenciaConsulta> _repositorioFrequenciaMock;
+        private readonly ObterAulasComFrequenciaPorTurmaCodigoQueryHandler _handler;
+        private readonly Faker _faker;
+
+        public ObterAulasComFrequenciaPorTurmaCodigoQueryHandlerTeste()
+        {
+            _repositorioFrequenciaMock = new Mock<IRepositorioFrequenciaConsulta>();
+            _handler = new ObterAulasComFrequenciaPorTurmaCodigoQueryHandler(_repositorioFrequenciaMock.Object);
+            _faker = new Faker("pt_BR");
+        }
+
+        [Fact(DisplayName = "Deve lançar exceção quando o repositório for nulo")]
+        public void DeveLancarExcecao_QuandoRepositorioNulo()
+        {
+            // Arrange & Act & Assert
+            Assert.Throws<ArgumentNullException>(() => new ObterAulasComFrequenciaPorTurmaCodigoQueryHandler(null));
+        }
+
+        [Fact(DisplayName = "Deve chamar o repositório para obter aulas com frequência e retornar os dados")]
+        public async Task DeveChamarRepositorio_E_RetornarAulasComFrequencia()
+        {
+            // Arrange
+            var turmaCodigo = _faker.Random.AlphaNumeric(5);
+            var query = new ObterAulasComFrequenciaPorTurmaCodigoQuery(turmaCodigo);
+
+            var retornoRepositorio = new List<AulaComFrequenciaNaDataDto>
+            {
+                new AulaComFrequenciaNaDataDto
+                {
+                    AulaId = _faker.Random.Long(1, 1000),
+                    DataAula = DateTime.Now.Date,
+                    RegistroFrequenciaId = _faker.Random.Long(1001, 2000)
+                }
+            };
+
+            _repositorioFrequenciaMock
+                .Setup(r => r.ObterAulasComRegistroFrequenciaPorTurma(turmaCodigo))
+                .ReturnsAsync(retornoRepositorio);
+
+            // Act
+            var resultado = await _handler.Handle(query, CancellationToken.None);
+
+            // Assert
+            _repositorioFrequenciaMock.Verify(r => r.ObterAulasComRegistroFrequenciaPorTurma(turmaCodigo), Times.Once);
+            Assert.Same(retornoRepositorio, resultado);
+        }
+    }
+}

--- a/teste/SME.SGP.Aplicacao.Teste/Queries/Frequencia/ObterAusenciaMotivoPorAlunoTurmaBimestreAnoQueryHandlerTeste.cs
+++ b/teste/SME.SGP.Aplicacao.Teste/Queries/Frequencia/ObterAusenciaMotivoPorAlunoTurmaBimestreAnoQueryHandlerTeste.cs
@@ -1,0 +1,66 @@
+﻿using Bogus;
+using Moq;
+using SME.SGP.Dominio.Interfaces;
+using SME.SGP.Infra;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace SME.SGP.Aplicacao.Teste.Queries.Frequencia
+{
+    public class ObterAusenciaMotivoPorAlunoTurmaBimestreAnoQueryHandlerTeste
+    {
+        private readonly Mock<IRepositorioFrequenciaConsulta> _repositorioFrequenciaMock;
+        private readonly ObterAusenciaMotivoPorAlunoTurmaBimestreAnoQueryHandler _handler;
+        private readonly Faker _faker;
+
+        public ObterAusenciaMotivoPorAlunoTurmaBimestreAnoQueryHandlerTeste()
+        {
+            _repositorioFrequenciaMock = new Mock<IRepositorioFrequenciaConsulta>();
+            _handler = new ObterAusenciaMotivoPorAlunoTurmaBimestreAnoQueryHandler(_repositorioFrequenciaMock.Object);
+            _faker = new Faker("pt_BR");
+        }
+
+        [Fact(DisplayName = "Deve lançar exceção quando o repositório for nulo")]
+        public void DeveLancarExcecao_QuandoRepositorioNulo()
+        {
+            // Arrange & Act & Assert
+            Assert.Throws<ArgumentNullException>(() => new ObterAusenciaMotivoPorAlunoTurmaBimestreAnoQueryHandler(null));
+        }
+
+        [Fact(DisplayName = "Deve chamar o repositório para obter os motivos de ausência e retornar os dados")]
+        public async Task DeveChamarRepositorio_E_RetornarMotivosDeAusencia()
+        {
+            // Arrange
+            var alunoCodigo = _faker.Random.AlphaNumeric(8);
+            var turmaCodigo = _faker.Random.AlphaNumeric(5);
+            short bimestre = 1;
+            short anoLetivo = (short)DateTime.Now.Year;
+
+            var query = new ObterAusenciaMotivoPorAlunoTurmaBimestreAnoQuery(alunoCodigo, turmaCodigo, bimestre, anoLetivo);
+
+            var retornoRepositorio = new List<AusenciaMotivoDto>
+            {
+                new AusenciaMotivoDto
+                {
+                    DataAusencia = DateTime.Now.Date,
+                    MotivoAusencia = "Atestado Médico",
+                    RegistradoPor = "PROFESSOR TESTE"
+                }
+            };
+
+            _repositorioFrequenciaMock
+                .Setup(r => r.ObterAusenciaMotivoPorAlunoTurmaBimestreAno(alunoCodigo, turmaCodigo, bimestre, anoLetivo))
+                .ReturnsAsync(retornoRepositorio);
+
+            // Act
+            var resultado = await _handler.Handle(query, CancellationToken.None);
+
+            // Assert
+            _repositorioFrequenciaMock.Verify(r => r.ObterAusenciaMotivoPorAlunoTurmaBimestreAno(alunoCodigo, turmaCodigo, bimestre, anoLetivo), Times.Once);
+            Assert.Same(retornoRepositorio, resultado);
+        }
+    }
+}

--- a/teste/SME.SGP.Aplicacao.Teste/Queries/Frequencia/ObterConsultaFrequenciaGeralAlunoQueryHandlerTeste.cs
+++ b/teste/SME.SGP.Aplicacao.Teste/Queries/Frequencia/ObterConsultaFrequenciaGeralAlunoQueryHandlerTeste.cs
@@ -1,0 +1,121 @@
+﻿using Bogus;
+using MediatR;
+using Moq;
+using SME.SGP.Dominio.Enumerados;
+using SME.SGP.Dominio;
+using SME.SGP.Infra;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace SME.SGP.Aplicacao.Teste.Queries.Frequencia
+{
+    public class ObterConsultaFrequenciaGeralAlunoQueryHandlerTeste
+    {
+        private readonly Mock<IMediator> _mediatorMock;
+        private readonly ObterConsultaFrequenciaGeralAlunoQueryHandler _handler;
+        private readonly Faker _faker;
+
+        public ObterConsultaFrequenciaGeralAlunoQueryHandlerTeste()
+        {
+            _mediatorMock = new Mock<IMediator>();
+            _handler = new ObterConsultaFrequenciaGeralAlunoQueryHandler(_mediatorMock.Object);
+            _faker = new Faker("pt_BR");
+        }
+
+        [Fact(DisplayName = "Deve lançar exceção quando o mediator for nulo")]
+        public void DeveLancarExcecao_QuandoMediatorNulo()
+        {
+            // Arrange & Act & Assert
+            Assert.Throws<ArgumentNullException>(() => new ObterConsultaFrequenciaGeralAlunoQueryHandler(null));
+        }
+
+        [Fact(DisplayName = "Deve incluir apenas a turma da query quando não for regular ou de itinerário")]
+        public async Task Handle_QuandoTurmaNaoRegularOuItinerario_DeveConsultarApenasTurmaAtual()
+        {
+            // Arrange
+            var query = new ObterConsultaFrequenciaGeralAlunoQuery("ALUNO1", "TURMA_PROGRAMA");
+            var turma = new Turma { CodigoTurma = query.TurmaCodigo, TipoTurma = TipoTurma.Programa };
+            var retornoFrequencia = "95,00%";
+
+            _mediatorMock.Setup(m => m.Send(It.Is<ObterTurmaComUeEDrePorCodigoQuery>(q => q.TurmaCodigo == query.TurmaCodigo), It.IsAny<CancellationToken>()))
+                         .ReturnsAsync(turma);
+            _mediatorMock.Setup(m => m.Send(It.IsAny<ObterTurmaItinerarioEnsinoMedioQuery>(), It.IsAny<CancellationToken>()))
+                         .ReturnsAsync(new List<TurmaItinerarioEnsinoMedioDto>());
+            _mediatorMock.Setup(m => m.Send(It.Is<ObterAlunoPorTurmaAlunoCodigoQuery>(q => q.TurmaCodigo == query.TurmaCodigo), It.IsAny<CancellationToken>()))
+                         .ReturnsAsync(new AlunoPorTurmaResposta { CodigoSituacaoMatricula = SituacaoMatriculaAluno.Ativo });
+            _mediatorMock.Setup(m => m.Send(It.Is<ObterConsultaFrequenciaGeralAlunoPorTurmasQuery>(q => q.TurmaCodigo.Length == 1 && q.TurmaCodigo[0] == query.TurmaCodigo), It.IsAny<CancellationToken>()))
+                         .ReturnsAsync(retornoFrequencia);
+
+            // Act
+            var resultado = await _handler.Handle(query, CancellationToken.None);
+
+            // Assert
+            Assert.Equal(retornoFrequencia, resultado);
+            _mediatorMock.Verify(m => m.Send(It.IsAny<ObterTurmaCodigosAlunoPorAnoLetivoAlunoTipoTurmaQuery>(), It.IsAny<CancellationToken>()), Times.Never);
+        }
+
+        [Fact(DisplayName = "Deve buscar outras turmas regulares quando a turma principal for regular e aluno estiver ativo")]
+        public async Task Handle_QuandoTurmaRegularEAlunoAtivo_DeveBuscarOutrasTurmas()
+        {
+            // Arrange
+            var query = new ObterConsultaFrequenciaGeralAlunoQuery("ALUNO1", "TURMA_REGULAR");
+            var turma = new Turma { CodigoTurma = query.TurmaCodigo, TipoTurma = TipoTurma.Regular };
+            var turmasDoAluno = new[] { "TURMA_ED_FISICA", "TURMA_ITINERARIO" };
+            var retornoFrequencia = "98,00%";
+
+            _mediatorMock.Setup(m => m.Send(It.Is<ObterTurmaComUeEDrePorCodigoQuery>(q => q.TurmaCodigo == query.TurmaCodigo), It.IsAny<CancellationToken>()))
+                         .ReturnsAsync(turma);
+            _mediatorMock.Setup(m => m.Send(It.IsAny<ObterTurmaItinerarioEnsinoMedioQuery>(), It.IsAny<CancellationToken>()))
+                         .ReturnsAsync(new List<TurmaItinerarioEnsinoMedioDto> { new TurmaItinerarioEnsinoMedioDto { Id = (int)TipoTurma.ItinerarioEnsMedio } });
+            _mediatorMock.Setup(m => m.Send(It.Is<ObterAlunoPorTurmaAlunoCodigoQuery>(q => q.TurmaCodigo == query.TurmaCodigo), It.IsAny<CancellationToken>()))
+                         .ReturnsAsync(new AlunoPorTurmaResposta { CodigoSituacaoMatricula = SituacaoMatriculaAluno.Ativo });
+            _mediatorMock.Setup(m => m.Send(It.IsAny<ObterTurmaCodigosAlunoPorAnoLetivoAlunoTipoTurmaQuery>(), It.IsAny<CancellationToken>()))
+                        .ReturnsAsync(turmasDoAluno);
+            _mediatorMock.Setup(m => m.Send(It.IsAny<ObterTurmasPorCodigosQuery>(), It.IsAny<CancellationToken>()))
+                        .ReturnsAsync(new List<Turma>());
+            _mediatorMock.Setup(m => m.Send(It.Is<ObterConsultaFrequenciaGeralAlunoPorTurmasQuery>(q => q.TurmaCodigo.Length == turmasDoAluno.Length), It.IsAny<CancellationToken>()))
+                         .ReturnsAsync(retornoFrequencia);
+
+            // Act
+            var resultado = await _handler.Handle(query, CancellationToken.None);
+
+            // Assert
+            Assert.Equal(retornoFrequencia, resultado);
+            _mediatorMock.Verify(m => m.Send(It.IsAny<ObterTurmaCodigosAlunoPorAnoLetivoAlunoTipoTurmaQuery>(), It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact(DisplayName = "Deve incluir turma principal na busca quando aluno estiver inativo na turma regular")]
+        public async Task Handle_QuandoTurmaRegularEAlunoInativo_DeveIncluirTurmaPrincipalNaBusca()
+        {
+            // Arrange
+            var query = new ObterConsultaFrequenciaGeralAlunoQuery("ALUNO1", "TURMA_REGULAR");
+            var turma = new Turma { CodigoTurma = query.TurmaCodigo, TipoTurma = TipoTurma.Regular };
+            var retornoFrequencia = "75,00%";
+
+            _mediatorMock.Setup(m => m.Send(It.Is<ObterTurmaComUeEDrePorCodigoQuery>(q => q.TurmaCodigo == query.TurmaCodigo), It.IsAny<CancellationToken>()))
+                         .ReturnsAsync(turma);
+            _mediatorMock.Setup(m => m.Send(It.IsAny<ObterTurmaItinerarioEnsinoMedioQuery>(), It.IsAny<CancellationToken>()))
+                         .ReturnsAsync(new List<TurmaItinerarioEnsinoMedioDto>());
+            // Aluno inativo na turma da query
+            _mediatorMock.Setup(m => m.Send(It.Is<ObterAlunoPorTurmaAlunoCodigoQuery>(q => q.TurmaCodigo == query.TurmaCodigo), It.IsAny<CancellationToken>()))
+                         .ReturnsAsync(new AlunoPorTurmaResposta { CodigoSituacaoMatricula = SituacaoMatriculaAluno.Transferido });
+            _mediatorMock.Setup(m => m.Send(It.IsAny<ObterTurmaCodigosAlunoPorAnoLetivoAlunoTipoTurmaQuery>(), It.IsAny<CancellationToken>()))
+                         .ReturnsAsync(new string[0]); // Sem outras turmas
+            // A verificação deve incluir a turma da query
+            _mediatorMock.Setup(m => m.Send(It.Is<ObterConsultaFrequenciaGeralAlunoPorTurmasQuery>(q => q.TurmaCodigo.Contains(query.TurmaCodigo)), It.IsAny<CancellationToken>()))
+                         .ReturnsAsync(retornoFrequencia);
+
+            // Act
+            var resultado = await _handler.Handle(query, CancellationToken.None);
+
+            // Assert
+            Assert.Equal(retornoFrequencia, resultado);
+            _mediatorMock.Verify(m => m.Send(It.Is<ObterConsultaFrequenciaGeralAlunoPorTurmasQuery>(q => q.TurmaCodigo.Length == 1 && q.TurmaCodigo[0] == query.TurmaCodigo), It.IsAny<CancellationToken>()), Times.Once);
+        }
+    }
+}


### PR DESCRIPTION
Introduces comprehensive unit tests for various frequency-related query handlers, including ExigeAprovacaoDeNota, ExisteFrequenciaRegistradaPorTurmaComponenteCurricular, ObterAlunosAusentesPorTurmaNoPeriodo, ObterAulaPossuiFrequencia, ObterAulasComFrequenciaPorTurmaCodigo, ObterAusenciaMotivoPorAlunoTurmaBimestreAno, and ObterConsultaFrequenciaGeralAluno. These tests cover scenarios such as null dependencies, expected repository/mocked mediator calls, and different business logic branches.