### PR TITLE
Adiciona worker para consolidação dos indicadores de alfabetização critica

### DIFF
--- a/scripts/V737__CRIAR_TABELA_CONSOLIDACAO_ALFABETIZACAO_CRITICA_ESCRITA.sql
+++ b/scripts/V737__CRIAR_TABELA_CONSOLIDACAO_ALFABETIZACAO_CRITICA_ESCRITA.sql
@@ -1,0 +1,11 @@
+CREATE table if not exists public.consolidacao_alfabetizacao_critica_escrita (
+	id int8 NOT NULL GENERATED ALWAYS AS IDENTITY,
+	dre_codigo varchar(15) not null,
+	ue_codigo varchar(15) not null,	
+	dre_nome varchar(100) not null,
+	ue_nome varchar(200) not null,
+	posicao int2 not null,
+	total_alunos_nao_alfabetizados int8 not null,
+	percentual_total_alunos NUMERIC(5, 2) not null,
+	CONSTRAINT consolidacao_alfabetizacao_critica_escrita_pk PRIMARY KEY (id)
+);

--- a/src/SME.SGP.Aplicacao/CasosDeUso/PainelEducacional/ConsolidarInformacoesAlfabetizacaoCriticaEscritaPainelEducacionalUseCase.cs
+++ b/src/SME.SGP.Aplicacao/CasosDeUso/PainelEducacional/ConsolidarInformacoesAlfabetizacaoCriticaEscritaPainelEducacionalUseCase.cs
@@ -1,0 +1,24 @@
+﻿using MediatR;
+using SME.SGP.Aplicacao.Commands.PainelEducacional.SalvarConsolidacaoAlfabetizacaoCriticaEscrita;
+using SME.SGP.Aplicacao.Interfaces;
+using SME.SGP.Aplicacao.Queries.Sondagem.ObterConsolidacaoAlfabetizacaoCriticaEscrita;
+using SME.SGP.Infra;
+using System.Threading.Tasks;
+
+namespace SME.SGP.Aplicacao.CasosDeUso.PainelEducacional
+{
+    public class ConsolidarInformacoesAlfabetizacaoCriticaEscritaPainelEducacionalUseCase: AbstractUseCase, IConsolidarInformacoesAlfabetizacaoCriticaEscritaPainelEducacionalUseCase
+    {
+        public ConsolidarInformacoesAlfabetizacaoCriticaEscritaPainelEducacionalUseCase(IMediator mediator) : base(mediator)
+        {
+        }
+        public async Task<bool> Executar(MensagemRabbit param)
+        {
+            var dadosConsolidadosSondagem = await mediator.Send(new ObterConsolidacaoAlfabetizacaoCriticaEscritaQuery());
+            if (dadosConsolidadosSondagem is null)
+                return false;
+            await mediator.Send(new SalvarConsolidacaoAlfabetizacaoCriticaEscritaCommand(dadosConsolidadosSondagem));
+            return true;
+        }
+    }
+}

--- a/src/SME.SGP.Aplicacao/Commands/PainelEducacional/SalvarConsolidacaoAlfabetizacaoCriticaEscrita/SalvarConsolidacaoAlfabetizacaoCriticaEscritaCommand.cs
+++ b/src/SME.SGP.Aplicacao/Commands/PainelEducacional/SalvarConsolidacaoAlfabetizacaoCriticaEscrita/SalvarConsolidacaoAlfabetizacaoCriticaEscritaCommand.cs
@@ -1,0 +1,16 @@
+﻿using MediatR;
+using SME.SGP.Infra.Dtos.Sondagem;
+using System.Collections.Generic;
+
+namespace SME.SGP.Aplicacao.Commands.PainelEducacional.SalvarConsolidacaoAlfabetizacaoCriticaEscrita
+{
+    public class SalvarConsolidacaoAlfabetizacaoCriticaEscritaCommand : IRequest<bool>
+    {
+        public IEnumerable<SondagemConsolidacaoAlfabetizacaoCriticaEscritaDto> ConsolidacaoAlfabetizacaoCriticaEscrita { get; set; }
+
+        public SalvarConsolidacaoAlfabetizacaoCriticaEscritaCommand(IEnumerable<SondagemConsolidacaoAlfabetizacaoCriticaEscritaDto> consolidacaoAlfabetizacaoCriticaEscrita)
+        {
+            ConsolidacaoAlfabetizacaoCriticaEscrita = consolidacaoAlfabetizacaoCriticaEscrita;
+        }
+    }
+}

--- a/src/SME.SGP.Aplicacao/Commands/PainelEducacional/SalvarConsolidacaoAlfabetizacaoCriticaEscrita/SalvarConsolidacaoAlfabetizacaoCriticaEscritaCommandHandler.cs
+++ b/src/SME.SGP.Aplicacao/Commands/PainelEducacional/SalvarConsolidacaoAlfabetizacaoCriticaEscrita/SalvarConsolidacaoAlfabetizacaoCriticaEscritaCommandHandler.cs
@@ -1,0 +1,73 @@
+﻿using MediatR;
+using SME.SGP.Dominio.Entidades;
+using SME.SGP.Dominio.Interfaces.Repositorios;
+using SME.SGP.Infra.Dtos.Sondagem;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SME.SGP.Aplicacao.Commands.PainelEducacional.SalvarConsolidacaoAlfabetizacaoCriticaEscrita
+{
+    public class SalvarConsolidacaoAlfabetizacaoCriticaEscritaCommandHandler : IRequestHandler<SalvarConsolidacaoAlfabetizacaoCriticaEscritaCommand, bool>
+    {
+        private readonly IMediator mediator;
+        private readonly IRepositorioConsolidacaoAlfabetizacaoCriticaEscrita repositorioConsolidacaoAlfabetizacaoCriticaEscrita;
+
+        public SalvarConsolidacaoAlfabetizacaoCriticaEscritaCommandHandler(IMediator mediator, IRepositorioConsolidacaoAlfabetizacaoCriticaEscrita repositorioConsolidacaoAlfabetizacaoCriticaEscrita)
+        {
+            this.mediator = mediator;
+            this.repositorioConsolidacaoAlfabetizacaoCriticaEscrita = repositorioConsolidacaoAlfabetizacaoCriticaEscrita;
+        }
+
+        public async Task<bool> Handle(SalvarConsolidacaoAlfabetizacaoCriticaEscritaCommand request, CancellationToken cancellationToken)
+        {
+            if (request is null || request.ConsolidacaoAlfabetizacaoCriticaEscrita is null || request.ConsolidacaoAlfabetizacaoCriticaEscrita.Count() == 0)
+                return false;
+
+            try
+            {
+                var dadosTratados = await TratarDadosAsync(request.ConsolidacaoAlfabetizacaoCriticaEscrita);
+                await repositorioConsolidacaoAlfabetizacaoCriticaEscrita.ExcluirConsolidacaoAlfabetizacaoCriticaEscrita();
+                foreach (var consolidacaoAlfabetizacaoCriticaEscrita in dadosTratados)
+                {
+                    await repositorioConsolidacaoAlfabetizacaoCriticaEscrita
+                        .SalvarConsolidacaoAlfabetizacaoCriticaEscrita(consolidacaoAlfabetizacaoCriticaEscrita);
+                }
+                return true;
+            }
+            catch (Exception ex)
+            {
+                throw new Exception($"Erro ao salvar consolidação da alfabetização crítica escrita. {ex.Message}");
+            }
+        }
+
+        private async Task<List<ConsolidacaoAlfabetizacaoCriticaEscrita>>
+            TratarDadosAsync(IEnumerable<SondagemConsolidacaoAlfabetizacaoCriticaEscritaDto> dto)
+        {
+            var uesCodigo = dto.Select(c => c.UeCodigo).Distinct();
+            var dresCodigo = dto.Select(c => c.DreCodigo).Distinct();
+            var ues = await mediator.Send(new ObterUesComDrePorCodigoUesQuery(uesCodigo.ToArray()));
+            var dtoOrdenado = dto.OrderByDescending(c => c.PercentualNaoAlfabetizados).ThenByDescending(c => c.QuantidadeNaoAlfabetizados);
+            var resultado = new List<ConsolidacaoAlfabetizacaoCriticaEscrita>();
+
+            foreach (var itemWithIndex in dtoOrdenado.Select((item, i) => new { Item = item, Index = i }))
+            {
+                var ue = ues.FirstOrDefault(u => u.CodigoUe == itemWithIndex.Item.UeCodigo && u.Dre.CodigoDre == itemWithIndex.Item.DreCodigo);
+                resultado.Add(new ConsolidacaoAlfabetizacaoCriticaEscrita()
+                {
+                    DreCodigo = itemWithIndex.Item.DreCodigo,
+                    UeCodigo = itemWithIndex.Item.UeCodigo,
+                    DreNome = ue.Dre.Nome,
+                    UeNome = ue.Nome,
+                    PercentualTotalAlunos = itemWithIndex.Item.PercentualNaoAlfabetizados,
+                    TotalAlunosNaoAlfabetizados = itemWithIndex.Item.QuantidadeNaoAlfabetizados,
+                    Posicao = itemWithIndex.Index + 1
+                });
+            }
+
+            return resultado;
+        }
+    }
+}

--- a/src/SME.SGP.Aplicacao/Interfaces/CasosDeUso/PainelEducacional/IConsolidarInformacoesAlfabetizacaoCriticaEscritaPainelEducacionalUseCase.cs
+++ b/src/SME.SGP.Aplicacao/Interfaces/CasosDeUso/PainelEducacional/IConsolidarInformacoesAlfabetizacaoCriticaEscritaPainelEducacionalUseCase.cs
@@ -1,0 +1,6 @@
+﻿namespace SME.SGP.Aplicacao.Interfaces
+{
+    public interface IConsolidarInformacoesAlfabetizacaoCriticaEscritaPainelEducacionalUseCase : IRabbitUseCase
+    {
+    }
+}

--- a/src/SME.SGP.Aplicacao/Queries/Sondagem/ObterConsolidacaoAlfabetizacaoCriticaEscrita/ObterConsolidacaoAlfabetizacaoCriticaEscritaQuery.cs
+++ b/src/SME.SGP.Aplicacao/Queries/Sondagem/ObterConsolidacaoAlfabetizacaoCriticaEscrita/ObterConsolidacaoAlfabetizacaoCriticaEscritaQuery.cs
@@ -1,0 +1,10 @@
+﻿using MediatR;
+using SME.SGP.Infra.Dtos.Sondagem;
+using System.Collections.Generic;
+
+namespace SME.SGP.Aplicacao.Queries.Sondagem.ObterConsolidacaoAlfabetizacaoCriticaEscrita
+{
+    public class ObterConsolidacaoAlfabetizacaoCriticaEscritaQuery : IRequest<IEnumerable<SondagemConsolidacaoAlfabetizacaoCriticaEscritaDto>>
+    {
+    }
+}

--- a/src/SME.SGP.Aplicacao/Queries/Sondagem/ObterConsolidacaoAlfabetizacaoCriticaEscrita/ObterConsolidacaoAlfabetizacaoCriticaEscritaQueryHandler.cs
+++ b/src/SME.SGP.Aplicacao/Queries/Sondagem/ObterConsolidacaoAlfabetizacaoCriticaEscrita/ObterConsolidacaoAlfabetizacaoCriticaEscritaQueryHandler.cs
@@ -1,0 +1,42 @@
+﻿using MediatR;
+using SME.SGP.Dominio.Enumerados;
+using SME.SGP.Infra.Consts;
+using SME.SGP.Infra.Dtos.Sondagem;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SME.SGP.Aplicacao.Queries.Sondagem.ObterConsolidacaoAlfabetizacaoCriticaEscrita
+{
+    public class ObterConsolidacaoAlfabetizacaoCriticaEscritaQueryHandler : IRequestHandler<ObterConsolidacaoAlfabetizacaoCriticaEscritaQuery, IEnumerable<SondagemConsolidacaoAlfabetizacaoCriticaEscritaDto>>
+    {
+        private readonly IHttpClientFactory httpClientFactory;
+        private readonly IMediator mediator;
+
+        public ObterConsolidacaoAlfabetizacaoCriticaEscritaQueryHandler(IHttpClientFactory httpClientFactory, IMediator mediator)
+        {
+            this.httpClientFactory = httpClientFactory;
+            this.mediator = mediator;
+        }
+        public async Task<IEnumerable<SondagemConsolidacaoAlfabetizacaoCriticaEscritaDto>> 
+            Handle(ObterConsolidacaoAlfabetizacaoCriticaEscritaQuery request, CancellationToken cancellationToken)
+        {
+            var httpClient = httpClientFactory.CreateClient(ServicoSondagemConstants.Servico);
+            var resposta = await httpClient.GetAsync(ServicoSondagemConstants.URL_CONSOLIDACAO_ALFABETIZACAO_CRITICA_ESCRITA);
+            if (resposta.IsSuccessStatusCode && resposta.StatusCode != HttpStatusCode.NoContent)
+            {
+                var json = await resposta.Content.ReadAsStringAsync();
+                return Newtonsoft.Json.JsonConvert.DeserializeObject<IEnumerable<SondagemConsolidacaoAlfabetizacaoCriticaEscritaDto>>(json);
+            }
+
+            if (!resposta.IsSuccessStatusCode)
+                await mediator.Send(new SalvarLogViaRabbitCommand($"Ocorreu um erro ao obter Consolidação Alfabetização Crítica Escrita, código de erro: {resposta.StatusCode}",
+                                                                  LogNivel.Critico,
+                                                                  LogContexto.ApiSondagem,
+                                                                  $"Mensagem: {await resposta.Content.ReadAsStringAsync()}, Request: {Newtonsoft.Json.JsonConvert.SerializeObject(resposta.RequestMessage)}"));
+            return new List<SondagemConsolidacaoAlfabetizacaoCriticaEscritaDto>();
+        }
+    }
+}

--- a/src/SME.SGP.Dados/Mapeamentos/ConsolidacaoAlfabetizacaoCriticaEscritaMap.cs
+++ b/src/SME.SGP.Dados/Mapeamentos/ConsolidacaoAlfabetizacaoCriticaEscritaMap.cs
@@ -1,0 +1,21 @@
+﻿using Dapper.FluentMap.Dommel.Mapping;
+using SME.SGP.Dominio.Entidades;
+
+namespace SME.SGP.Dados.Mapeamentos
+{
+    public class ConsolidacaoAlfabetizacaoCriticaEscritaMap : DommelEntityMap<ConsolidacaoAlfabetizacaoCriticaEscrita>
+    {
+        public ConsolidacaoAlfabetizacaoCriticaEscritaMap()
+        {
+            ToTable("consolidacao_alfabetizacao_critica_escrita");
+            Map(c => c.Id).ToColumn("id").IsIdentity().IsKey();
+            Map(c => c.DreCodigo).ToColumn("dre_codigo");
+            Map(c => c.UeCodigo).ToColumn("ue_codigo");
+            Map(c => c.DreNome).ToColumn("dre_nome");
+            Map(c => c.UeNome).ToColumn("ue_nome");
+            Map(c => c.Posicao).ToColumn("posicao");
+            Map(c => c.TotalAlunosNaoAlfabetizados).ToColumn("total_alunos_nao_alfabetizados");
+            Map(c => c.PercentualTotalAlunos).ToColumn("percentual_total_alunos");
+        }
+    }
+}

--- a/src/SME.SGP.Dados/Mapeamentos/RegistrarMapeamentos.cs
+++ b/src/SME.SGP.Dados/Mapeamentos/RegistrarMapeamentos.cs
@@ -267,6 +267,7 @@ namespace SME.SGP.Dados.Mapeamentos
                config.AddMap(new PainelEducacionalRegistroFrequenciaAgrupamentoGlobalMap());
                config.AddMap(new PainelEducacionalRegistroFrequenciaAgrupamentoEscolaMap());
                config.AddMap(new ConsolidacaoAlfabetizacaoNivelEscritaMap());
+               config.AddMap(new ConsolidacaoAlfabetizacaoCriticaEscritaMap());
 
                config.ForDommel();
            });

--- a/src/SME.SGP.Dados/Repositorios/RepositorioConsolidacaoAlfabetizacaoCriticaEscrita.cs
+++ b/src/SME.SGP.Dados/Repositorios/RepositorioConsolidacaoAlfabetizacaoCriticaEscrita.cs
@@ -1,0 +1,28 @@
+﻿using SME.SGP.Dominio.Entidades;
+using SME.SGP.Dominio.Interfaces.Repositorios;
+using SME.SGP.Infra;
+using System;
+using System.Threading.Tasks;
+
+namespace SME.SGP.Dados.Repositorios
+{
+    public class RepositorioConsolidacaoAlfabetizacaoCriticaEscrita : IRepositorioConsolidacaoAlfabetizacaoCriticaEscrita
+    {
+        private readonly ISgpContext database;
+
+        public RepositorioConsolidacaoAlfabetizacaoCriticaEscrita(ISgpContext database)
+        {
+            this.database = database ?? throw new ArgumentNullException(nameof(database));
+        }
+        public async Task ExcluirConsolidacaoAlfabetizacaoCriticaEscrita()
+        {
+            const string comando = @"truncate table public.consolidacao_alfabetizacao_critica_escrita";
+            await database.Conexao.ExecuteAsync(comando);
+        }
+
+        public async Task<bool> SalvarConsolidacaoAlfabetizacaoCriticaEscrita(ConsolidacaoAlfabetizacaoCriticaEscrita entidade)
+        {
+            return (long)(await database.Conexao.InsertAsync(entidade)) > 0;
+        }
+    }
+}

--- a/src/SME.SGP.Dados/Repositorios/RepositorioDreConsulta.cs
+++ b/src/SME.SGP.Dados/Repositorios/RepositorioDreConsulta.cs
@@ -28,6 +28,13 @@ namespace SME.SGP.Dados.Repositorios
             return contexto.Conexao.Query<Dre>(query, new { dresCodigos });
         }
 
+        public async Task<IEnumerable<Dre>> ListarPorCodigosAsync(string[] dresCodigos)
+        {
+            var query = "select id, dre_id, abreviacao, nome from dre d where d.dre_id = ANY(@dresCodigos)";
+
+            return await contexto.Conexao.QueryAsync<Dre>(query, new { dresCodigos });
+        }
+
         public (IEnumerable<Dre> Dres,string[] CodigosDresNaoEncontrados) MaterializarCodigosDre(string[] idDres)
         {
             string[] naoEncontradas;

--- a/src/SME.SGP.Dominio.Interfaces/Repositorios/IRepositorioConsolidacaoAlfabetizacaoCriticaEscrita.cs
+++ b/src/SME.SGP.Dominio.Interfaces/Repositorios/IRepositorioConsolidacaoAlfabetizacaoCriticaEscrita.cs
@@ -1,0 +1,11 @@
+﻿using SME.SGP.Dominio.Entidades;
+using System.Threading.Tasks;
+
+namespace SME.SGP.Dominio.Interfaces.Repositorios
+{
+    public interface IRepositorioConsolidacaoAlfabetizacaoCriticaEscrita
+    {
+        Task ExcluirConsolidacaoAlfabetizacaoCriticaEscrita();
+        Task<bool> SalvarConsolidacaoAlfabetizacaoCriticaEscrita(ConsolidacaoAlfabetizacaoCriticaEscrita entidade);
+    }
+}

--- a/src/SME.SGP.Dominio.Interfaces/Repositorios/IRepositorioDreConsulta.cs
+++ b/src/SME.SGP.Dominio.Interfaces/Repositorios/IRepositorioDreConsulta.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace SME.SGP.Dominio.Interfaces
@@ -7,6 +6,7 @@ namespace SME.SGP.Dominio.Interfaces
     public interface IRepositorioDreConsulta
     {
         IEnumerable<Dre> ListarPorCodigos(string[] dresCodigos);
+        Task<IEnumerable<Dre>> ListarPorCodigosAsync(string[] dresCodigos);
 
         (IEnumerable<Dre> Dres, string[] CodigosDresNaoEncontrados) MaterializarCodigosDre(string[] idDres);
 

--- a/src/SME.SGP.Dominio/Entidades/ConsolidacaoAlfabetizacaoCriticaEscrita.cs
+++ b/src/SME.SGP.Dominio/Entidades/ConsolidacaoAlfabetizacaoCriticaEscrita.cs
@@ -1,0 +1,14 @@
+﻿namespace SME.SGP.Dominio.Entidades
+{
+    public class ConsolidacaoAlfabetizacaoCriticaEscrita
+    {
+        public long Id { get; set; }
+        public string DreCodigo { get; set; }
+        public string UeCodigo { get; set; }
+        public string DreNome { get; set; }
+        public string UeNome { get; set; }
+        public int Posicao { get; set; }
+        public long TotalAlunosNaoAlfabetizados { get; set; }
+        public decimal PercentualTotalAlunos { get; set; }
+    }
+}

--- a/src/SME.SGP.Dominio/Entidades/PainelEducacionalNumeroEstudantesAgrupamentoNivelAlfabetizacao.cs
+++ b/src/SME.SGP.Dominio/Entidades/PainelEducacionalNumeroEstudantesAgrupamentoNivelAlfabetizacao.cs
@@ -1,27 +1,29 @@
-﻿using SME.SGP.Dominio;
-using System.ComponentModel.DataAnnotations.Schema;
+﻿using System.ComponentModel.DataAnnotations.Schema;
 
-[Table("consolidacao_alfabetizacao_nivel_escrita")]
-public class PainelEducacionalNumeroEstudantesAgrupamentoNivelAlfabetizacao : EntidadeBase
+namespace SME.SGP.Dominio.Entidades
 {
-    [Column("nivel_escrita")]
-    public string NivelAlfabetizacao { get; set; }
+    [Table("consolidacao_alfabetizacao_nivel_escrita")]
+    public class PainelEducacionalNumeroEstudantesAgrupamentoNivelAlfabetizacao : EntidadeBase
+    {
+        [Column("nivel_escrita")]
+        public string NivelAlfabetizacao { get; set; }
 
-    [NotMapped] // Não existe no banco, será calculado depois
-    public string NivelAlfabetizacaoDescricao { get; set; }
+        [NotMapped] // Não existe no banco, será calculado depois
+        public string NivelAlfabetizacaoDescricao { get; set; }
 
-    [Column("ue_codigo")]
-    public string Ue { get; set; }
+        [Column("ue_codigo")]
+        public string Ue { get; set; }
 
-    [Column("dre_codigo")]
-    public string Dre { get; set; }
+        [Column("dre_codigo")]
+        public string Dre { get; set; }
 
-    [Column("ano_letivo")]
-    public int Ano { get; set; }
+        [Column("ano_letivo")]
+        public int Ano { get; set; }
 
-    [Column("quantidade")]
-    public int TotalAlunos { get; set; }
+        [Column("quantidade")]
+        public int TotalAlunos { get; set; }
 
-    [Column("periodo")]
-    public int Periodo { get; set; }
+        [Column("periodo")]
+        public int Periodo { get; set; }
+    }
 }

--- a/src/SME.SGP.Infra.Consts/ServicoSondagemConstants.cs
+++ b/src/SME.SGP.Infra.Consts/ServicoSondagemConstants.cs
@@ -6,5 +6,6 @@
 
         public const string URL_LINGUA_PORTUGUESA_ALUNO = "integracoes/portugues/turmas/{0}/alunos/{1}";
         public const string URL_CONSOLIDACAO_NIVEL_ESCRITA_ALFABETIZACAO = "SondagemPortugues/ObterConsolidadoNivelEscrita";
+        public const string URL_CONSOLIDACAO_ALFABETIZACAO_CRITICA_ESCRITA = "SondagemPortugues/ObterConsoliadadoNivelEscritaCriticos";
     }
 }

--- a/src/SME.SGP.Infra.Mensageria/Rotas/RotasRabbitSgpPainelEducacional.cs
+++ b/src/SME.SGP.Infra.Mensageria/Rotas/RotasRabbitSgpPainelEducacional.cs
@@ -4,5 +4,6 @@
     {
         protected RotasRabbitSgpPainelEducacional() { }
         public const string ConsolidarNivelEscritaAlfabetizacao = "sgp.consolidar.nivel.escrita.alfabetizacao";
+        public const string ConsolidarNivelEscritaAlfabetizacaoCritico = "sgp.consolidar.nivel.escrita.alfabetizacao.critico";
     }
 }

--- a/src/SME.SGP.Infra/Dtos/Sondagem/SondagemConsolidacaoAlfabetizacaoCriticaEscritaDto.cs
+++ b/src/SME.SGP.Infra/Dtos/Sondagem/SondagemConsolidacaoAlfabetizacaoCriticaEscritaDto.cs
@@ -1,0 +1,10 @@
+﻿namespace SME.SGP.Infra.Dtos.Sondagem
+{
+    public class SondagemConsolidacaoAlfabetizacaoCriticaEscritaDto
+    {
+        public string DreCodigo { get; set; }
+        public string UeCodigo { get; set; }
+        public int QuantidadeNaoAlfabetizados { get; set; }
+        public decimal PercentualNaoAlfabetizados { get; set; }
+    }
+}

--- a/src/SME.SGP.IoC/Extensions/RegistrarCasoDeUsoRabbitSgp/RegistrarPainelEducacionalUseCaseRabbitSgp.cs
+++ b/src/SME.SGP.IoC/Extensions/RegistrarCasoDeUsoRabbitSgp/RegistrarPainelEducacionalUseCaseRabbitSgp.cs
@@ -10,7 +10,9 @@ namespace SME.SGP.IoC.Extensions.RegistrarCasoDeUsoRabbitSgp
         {
             services
                 .AddScoped<IConsolidarInformacoesNivelEscritaAlfabetizacaoPainelEducacionalUseCase, 
-                           ConsolidarInformacoesNivelEscritaAlfabetizacaoPainelEducacionalUseCase>();
+                           ConsolidarInformacoesNivelEscritaAlfabetizacaoPainelEducacionalUseCase>()
+                .AddScoped<IConsolidarInformacoesAlfabetizacaoCriticaEscritaPainelEducacionalUseCase,
+                           ConsolidarInformacoesAlfabetizacaoCriticaEscritaPainelEducacionalUseCase>();
         }
     }
 }

--- a/src/SME.SGP.IoC/RegistrarDependencias.cs
+++ b/src/SME.SGP.IoC/RegistrarDependencias.cs
@@ -623,6 +623,7 @@ namespace SME.SGP.IoC
             services.TryAddScoped<IRepositorioPainelEducacionalRegistroFrequenciaAgrupamentoMensal, RepositorioPainelEducacionalRegistroFrequenciaAgrupamentoMensal>(); 
             services.TryAddScoped<IRepositorioConsolidacaoAlfabetizacaoNivelEscrita, RepositorioConsolidacaoAlfabetizacaoNivelEscrita>();
             services.TryAddScoped<IRepositorioPainelEducacionalIndicadoresNivelAlfabetizacaoCritica, RepositorioPainelEducacionalIndicadoresNivelAlfabetizacaoCritica>();
+            services.TryAddScoped<IRepositorioConsolidacaoAlfabetizacaoCriticaEscrita, RepositorioConsolidacaoAlfabetizacaoCriticaEscrita>();
         }
 
         protected virtual void RegistrarServicos(IServiceCollection services)

--- a/src/SME.SGP.PainelEducacional.Worker/WorkerRabbitPainelEducacional.cs
+++ b/src/SME.SGP.PainelEducacional.Worker/WorkerRabbitPainelEducacional.cs
@@ -29,6 +29,7 @@ namespace SME.SGP.PainelEducacional.Worker
         protected override void RegistrarUseCases()
         {
             Comandos.Add(RotasRabbitSgpPainelEducacional.ConsolidarNivelEscritaAlfabetizacao, new ComandoRabbit("Sincronização e Consolidação dos Dados da Sondagem do Nível de Escrita", typeof(IConsolidarInformacoesNivelEscritaAlfabetizacaoPainelEducacionalUseCase), false));
+            Comandos.Add(RotasRabbitSgpPainelEducacional.ConsolidarNivelEscritaAlfabetizacaoCritico, new ComandoRabbit("Sincronização e Consolidação dos Dados da Sondagem da Alfabetização Crítica Escrita", typeof(IConsolidarInformacoesAlfabetizacaoCriticaEscritaPainelEducacionalUseCase), false));
         }
     }
 }

--- a/teste/SME.SGP.Aplicacao.Teste/CasosDeUso/PainelEducacional/ConsolidarInformacoesAlfabetizacaoCriticaEscritaPainelEducacionalUseCaseTeste.cs
+++ b/teste/SME.SGP.Aplicacao.Teste/CasosDeUso/PainelEducacional/ConsolidarInformacoesAlfabetizacaoCriticaEscritaPainelEducacionalUseCaseTeste.cs
@@ -1,0 +1,98 @@
+﻿using Bogus;
+using FluentAssertions;
+using MediatR;
+using Moq;
+using SME.SGP.Aplicacao.CasosDeUso.PainelEducacional;
+using SME.SGP.Aplicacao.Commands.PainelEducacional.SalvarConsolidacaoAlfabetizacaoCriticaEscrita;
+using SME.SGP.Aplicacao.Queries.Sondagem.ObterConsolidacaoAlfabetizacaoCriticaEscrita;
+using SME.SGP.Infra;
+using SME.SGP.Infra.Dtos.Sondagem;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace SME.SGP.Aplicacao.Teste.CasosDeUso.PainelEducacional
+{
+    public class ConsolidarInformacoesAlfabetizacaoCriticaEscritaPainelEducacionalUseCaseTeste
+    {
+        private readonly Mock<IMediator> _mediatorMock;
+        private readonly ConsolidarInformacoesAlfabetizacaoCriticaEscritaPainelEducacionalUseCase _sut;
+        private readonly Faker<SondagemConsolidacaoAlfabetizacaoCriticaEscritaDto> _dtoFaker;
+
+        public ConsolidarInformacoesAlfabetizacaoCriticaEscritaPainelEducacionalUseCaseTeste()
+        {
+            _mediatorMock = new Mock<IMediator>();
+            _sut = new ConsolidarInformacoesAlfabetizacaoCriticaEscritaPainelEducacionalUseCase(_mediatorMock.Object);
+
+            _dtoFaker = new Faker<SondagemConsolidacaoAlfabetizacaoCriticaEscritaDto>("pt_BR")
+                .RuleFor(s => s.DreCodigo, f => f.Random.AlphaNumeric(10).ToUpper())
+                .RuleFor(s => s.UeCodigo, f => f.Random.AlphaNumeric(10).ToUpper())
+                .RuleFor(s => s.QuantidadeNaoAlfabetizados, f => f.Random.Int(1, 50))
+                .RuleFor(s => s.PercentualNaoAlfabetizados, f => f.Random.Decimal(1, 100));
+        }
+
+        [Fact]
+        public async Task Executar_QuandoDadosSaoObtidosESalvosComSucesso_DeveRetornarTrue()
+        {
+            // Arrange
+            var dadosConsolidados = _dtoFaker.Generate(3);
+            var mensagemRabbit = new MensagemRabbit();
+
+            _mediatorMock
+                .Setup(m => m.Send(It.IsAny<ObterConsolidacaoAlfabetizacaoCriticaEscritaQuery>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(dadosConsolidados);
+
+            _mediatorMock
+                .Setup(m => m.Send(It.IsAny<SalvarConsolidacaoAlfabetizacaoCriticaEscritaCommand>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(true);
+
+            // Act
+            var resultado = await _sut.Executar(mensagemRabbit);
+
+            // Assert
+            resultado.Should().BeTrue();
+            _mediatorMock.Verify(m => m.Send(It.IsAny<ObterConsolidacaoAlfabetizacaoCriticaEscritaQuery>(), It.IsAny<CancellationToken>()), Times.Once);
+            _mediatorMock.Verify(m => m.Send(It.IsAny<SalvarConsolidacaoAlfabetizacaoCriticaEscritaCommand>(), It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task Executar_QuandoQueryRetornaNulo_DeveRetornarFalseENaoChamarSalvar()
+        {
+            // Arrange
+            var mensagemRabbit = new MensagemRabbit();
+
+            _mediatorMock
+                .Setup(m => m.Send(It.IsAny<ObterConsolidacaoAlfabetizacaoCriticaEscritaQuery>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((IEnumerable<SondagemConsolidacaoAlfabetizacaoCriticaEscritaDto>)null);
+
+            // Act
+            var resultado = await _sut.Executar(mensagemRabbit);
+
+            // Assert
+            resultado.Should().BeFalse();
+            _mediatorMock.Verify(m => m.Send(It.IsAny<ObterConsolidacaoAlfabetizacaoCriticaEscritaQuery>(), It.IsAny<CancellationToken>()), Times.Once);
+            _mediatorMock.Verify(m => m.Send(It.IsAny<SalvarConsolidacaoAlfabetizacaoCriticaEscritaCommand>(), It.IsAny<CancellationToken>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task Executar_QuandoMediatorLancaExcecao_DevePropagarExcecao()
+        {
+            // Arrange
+            var mensagemRabbit = new MensagemRabbit();
+            var mensagemErro = "Erro simulado ao buscar dados";
+
+            _mediatorMock
+                .Setup(m => m.Send(It.IsAny<ObterConsolidacaoAlfabetizacaoCriticaEscritaQuery>(), It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new InvalidOperationException(mensagemErro));
+
+            // Act
+            Func<Task> act = async () => await _sut.Executar(mensagemRabbit);
+
+            // Assert
+            await act.Should().ThrowAsync<InvalidOperationException>().WithMessage(mensagemErro);
+            _mediatorMock.Verify(m => m.Send(It.IsAny<SalvarConsolidacaoAlfabetizacaoCriticaEscritaCommand>(), It.IsAny<CancellationToken>()), Times.Never);
+        }
+    }
+}

--- a/teste/SME.SGP.Aplicacao.Teste/Commands/PainelEducacional/SalvarConsolidacaoAlfabetizacaoCriticaEscritaCommandHandlerTeste.cs
+++ b/teste/SME.SGP.Aplicacao.Teste/Commands/PainelEducacional/SalvarConsolidacaoAlfabetizacaoCriticaEscritaCommandHandlerTeste.cs
@@ -1,0 +1,109 @@
+﻿using Bogus;
+using FluentAssertions;
+using MediatR;
+using Moq;
+using SME.SGP.Aplicacao.Commands.PainelEducacional.SalvarConsolidacaoAlfabetizacaoCriticaEscrita;
+using SME.SGP.Dominio;
+using SME.SGP.Dominio.Entidades;
+using SME.SGP.Dominio.Interfaces.Repositorios;
+using SME.SGP.Infra.Dtos.Sondagem;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace SME.SGP.Aplicacao.Teste.Commands.PainelEducacional
+{
+    public class SalvarConsolidacaoAlfabetizacaoCriticaEscritaCommandHandlerTeste
+    {
+        private readonly Mock<IMediator> _mediatorMock;
+        private readonly Mock<IRepositorioConsolidacaoAlfabetizacaoCriticaEscrita> _repositorioMock;
+        private readonly SalvarConsolidacaoAlfabetizacaoCriticaEscritaCommandHandler _sut;
+        private readonly Faker _faker;
+
+        public SalvarConsolidacaoAlfabetizacaoCriticaEscritaCommandHandlerTeste()
+        {
+            _mediatorMock = new Mock<IMediator>();
+            _repositorioMock = new Mock<IRepositorioConsolidacaoAlfabetizacaoCriticaEscrita>();
+            _sut = new SalvarConsolidacaoAlfabetizacaoCriticaEscritaCommandHandler(_mediatorMock.Object, _repositorioMock.Object);
+            _faker = new Faker("pt_BR");
+        }
+
+        [Theory(DisplayName = "Deve retornar false para entradas inválidas sem acionar dependências")]
+        [MemberData(nameof(ComandosInvalidos))]
+        public async Task Handle_QuandoComandoInvalido_DeveRetornarFalse(SalvarConsolidacaoAlfabetizacaoCriticaEscritaCommand comando)
+        {
+            // Arrange & Act
+            var resultado = await _sut.Handle(comando, CancellationToken.None);
+
+            // Assert
+            resultado.Should().BeFalse();
+            _mediatorMock.Verify(m => m.Send(It.IsAny<IRequest<IEnumerable<Ue>>>(), It.IsAny<CancellationToken>()), Times.Never);
+            _repositorioMock.Verify(r => r.ExcluirConsolidacaoAlfabetizacaoCriticaEscrita(), Times.Never);
+            _repositorioMock.Verify(r => r.SalvarConsolidacaoAlfabetizacaoCriticaEscrita(It.IsAny<ConsolidacaoAlfabetizacaoCriticaEscrita>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task Handle_QuandoComandoValido_DeveOrdenarEnriquecerSalvarERetornarTrue()
+        {
+            // Arrange
+            var dtosNaoOrdenados = new List<SondagemConsolidacaoAlfabetizacaoCriticaEscritaDto>
+            {
+                new() { DreCodigo = "DRE1", UeCodigo = "UE1", PercentualNaoAlfabetizados = 50, QuantidadeNaoAlfabetizados = 10 },
+                new() { DreCodigo = "DRE2", UeCodigo = "UE2", PercentualNaoAlfabetizados = 75, QuantidadeNaoAlfabetizados = 30 }, // Deverá ser o primeiro
+                new() { DreCodigo = "DRE2", UeCodigo = "UE3", PercentualNaoAlfabetizados = 75, QuantidadeNaoAlfabetizados = 20 }  // Deverá ser o segundo
+            };
+            var comando = new SalvarConsolidacaoAlfabetizacaoCriticaEscritaCommand(dtosNaoOrdenados);
+
+            var uesRetorno = new List<Ue>
+            {
+                new() { CodigoUe = "UE1", Nome = "EMEF UE 1", Dre = new Dre { CodigoDre = "DRE1", Nome = "DRE UM" } },
+                new() { CodigoUe = "UE2", Nome = "EMEF UE 2", Dre = new Dre { CodigoDre = "DRE2", Nome = "DRE DOIS" } },
+                new() { CodigoUe = "UE3", Nome = "EMEF UE 3", Dre = new Dre { CodigoDre = "DRE2", Nome = "DRE DOIS" } }
+            };
+
+            _mediatorMock.Setup(m => m.Send(It.IsAny<ObterUesComDrePorCodigoUesQuery>(), It.IsAny<CancellationToken>()))
+                         .ReturnsAsync(uesRetorno);
+
+            var capturadorDeEntidades = new List<ConsolidacaoAlfabetizacaoCriticaEscrita>();
+            _repositorioMock.Setup(r => r.SalvarConsolidacaoAlfabetizacaoCriticaEscrita(It.IsAny<ConsolidacaoAlfabetizacaoCriticaEscrita>()))
+                           .Callback<ConsolidacaoAlfabetizacaoCriticaEscrita>(entidade => capturadorDeEntidades.Add(entidade))
+                           .ReturnsAsync(true);
+
+            // Act
+            var resultado = await _sut.Handle(comando, CancellationToken.None);
+
+            // Assert
+            resultado.Should().BeTrue();
+            _mediatorMock.Verify(m => m.Send(It.Is<ObterUesComDrePorCodigoUesQuery>(q => q.UesCodigos.Length == 3), It.IsAny<CancellationToken>()), Times.Once);
+            _repositorioMock.Verify(r => r.ExcluirConsolidacaoAlfabetizacaoCriticaEscrita(), Times.Once);
+            _repositorioMock.Verify(r => r.SalvarConsolidacaoAlfabetizacaoCriticaEscrita(It.IsAny<ConsolidacaoAlfabetizacaoCriticaEscrita>()), Times.Exactly(3));
+
+            // Valida a ordem e os dados enriquecidos
+            capturadorDeEntidades.Should().HaveCount(3);
+
+            // Posição 1
+            capturadorDeEntidades[0].Posicao.Should().Be(1);
+            capturadorDeEntidades[0].UeCodigo.Should().Be("UE2");
+            capturadorDeEntidades[0].UeNome.Should().Be("EMEF UE 2");
+            capturadorDeEntidades[0].DreNome.Should().Be("DRE DOIS");
+            capturadorDeEntidades[0].TotalAlunosNaoAlfabetizados.Should().Be(30);
+
+            // Posição 2
+            capturadorDeEntidades[1].Posicao.Should().Be(2);
+            capturadorDeEntidades[1].UeCodigo.Should().Be("UE3");
+
+            // Posição 3
+            capturadorDeEntidades[2].Posicao.Should().Be(3);
+            capturadorDeEntidades[2].UeCodigo.Should().Be("UE1");
+        }
+
+        public static IEnumerable<object[]> ComandosInvalidos =>
+            new List<object[]>
+            {
+                new object[] { null },
+                new object[] { new SalvarConsolidacaoAlfabetizacaoCriticaEscritaCommand(null) },
+                new object[] { new SalvarConsolidacaoAlfabetizacaoCriticaEscritaCommand(new List<SondagemConsolidacaoAlfabetizacaoCriticaEscritaDto>()) }
+            };
+    }
+}

--- a/teste/SME.SGP.Aplicacao.Teste/Queries/Sondagem/ObterConsolidacaoAlfabetizacaoCriticaEscritaQueryHandlerTeste.cs
+++ b/teste/SME.SGP.Aplicacao.Teste/Queries/Sondagem/ObterConsolidacaoAlfabetizacaoCriticaEscritaQueryHandlerTeste.cs
@@ -1,0 +1,120 @@
+﻿using Bogus;
+using FluentAssertions;
+using MediatR;
+using Moq;
+using Moq.Protected;
+using Newtonsoft.Json;
+using SME.SGP.Aplicacao.Queries.Sondagem.ObterConsolidacaoAlfabetizacaoCriticaEscrita;
+using SME.SGP.Infra.Consts;
+using SME.SGP.Infra.Dtos.Sondagem;
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace SME.SGP.Aplicacao.Teste.Queries.Sondagem
+{
+    public class ObterConsolidacaoAlfabetizacaoCriticaEscritaQueryHandlerTeste
+    {
+        private readonly Mock<IHttpClientFactory> _httpClientFactoryMock;
+        private readonly Mock<IMediator> _mediatorMock;
+        private readonly ObterConsolidacaoAlfabetizacaoCriticaEscritaQueryHandler _sut;
+        private readonly Faker<SondagemConsolidacaoAlfabetizacaoCriticaEscritaDto> _dtoFaker;
+
+        public ObterConsolidacaoAlfabetizacaoCriticaEscritaQueryHandlerTeste()
+        {
+            _httpClientFactoryMock = new Mock<IHttpClientFactory>();
+            _mediatorMock = new Mock<IMediator>();
+            _sut = new ObterConsolidacaoAlfabetizacaoCriticaEscritaQueryHandler(_httpClientFactoryMock.Object, _mediatorMock.Object);
+
+            _dtoFaker = new Faker<SondagemConsolidacaoAlfabetizacaoCriticaEscritaDto>("pt_BR")
+                .RuleFor(s => s.DreCodigo, f => f.Random.AlphaNumeric(10).ToUpper())
+                .RuleFor(s => s.UeCodigo, f => f.Random.AlphaNumeric(10).ToUpper())
+                .RuleFor(s => s.QuantidadeNaoAlfabetizados, f => f.Random.Int(1, 50))
+                .RuleFor(s => s.PercentualNaoAlfabetizados, f => f.Random.Decimal(1, 100));
+        }
+
+        private void ConfigurarMockHttpClient(HttpStatusCode statusCode, string jsonContent)
+        {
+            var httpMessageHandlerMock = new Mock<HttpMessageHandler>();
+            var resposta = new HttpResponseMessage
+            {
+                StatusCode = statusCode,
+                Content = new StringContent(jsonContent, Encoding.UTF8, "application/json")
+            };
+
+            httpMessageHandlerMock
+               .Protected()
+               .Setup<Task<HttpResponseMessage>>(
+                  "SendAsync",
+                  ItExpr.IsAny<HttpRequestMessage>(),
+                  ItExpr.IsAny<CancellationToken>()
+               )
+               .ReturnsAsync(resposta);
+
+            var httpClient = new HttpClient(httpMessageHandlerMock.Object)
+            {
+                BaseAddress = new Uri("http://localhost:5001/")
+            };
+
+            _httpClientFactoryMock.Setup(f => f.CreateClient(ServicoSondagemConstants.Servico)).Returns(httpClient);
+        }
+
+        [Fact]
+        public async Task Handle_QuandoRequisicaoSucedida_DeveRetornarConsolidacao()
+        {
+            // Arrange
+            var listaEsperada = _dtoFaker.Generate(5);
+            var jsonRetorno = JsonConvert.SerializeObject(listaEsperada);
+            ConfigurarMockHttpClient(HttpStatusCode.OK, jsonRetorno);
+
+            var query = new ObterConsolidacaoAlfabetizacaoCriticaEscritaQuery();
+
+            // Act
+            var resultado = await _sut.Handle(query, CancellationToken.None);
+
+            // Assert
+            resultado.Should().NotBeNull();
+            resultado.Should().BeEquivalentTo(listaEsperada);
+            _mediatorMock.Verify(m => m.Send(It.IsAny<SalvarLogViaRabbitCommand>(), It.IsAny<CancellationToken>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task Handle_QuandoRequisicaoRetornarSemConteudo_DeveRetornarListaVazia()
+        {
+            // Arrange
+            ConfigurarMockHttpClient(HttpStatusCode.NoContent, string.Empty);
+            var query = new ObterConsolidacaoAlfabetizacaoCriticaEscritaQuery();
+
+            // Act
+            var resultado = await _sut.Handle(query, CancellationToken.None);
+
+            // Assert
+            resultado.Should().NotBeNull();
+            resultado.Should().BeEmpty();
+            _mediatorMock.Verify(m => m.Send(It.IsAny<SalvarLogViaRabbitCommand>(), It.IsAny<CancellationToken>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task Handle_QuandoRequisicaoFalhar_DeveLogarErroERetornarListaVazia()
+        {
+            // Arrange
+            ConfigurarMockHttpClient(HttpStatusCode.InternalServerError, "Erro interno no servidor de sondagem.");
+            var query = new ObterConsolidacaoAlfabetizacaoCriticaEscritaQuery();
+
+            _mediatorMock.Setup(m => m.Send(It.IsAny<SalvarLogViaRabbitCommand>(), It.IsAny<CancellationToken>()))
+                         .ReturnsAsync(true);
+
+            // Act
+            var resultado = await _sut.Handle(query, CancellationToken.None);
+
+            // Assert
+            resultado.Should().NotBeNull();
+            resultado.Should().BeEmpty();
+            _mediatorMock.Verify(m => m.Send(It.IsAny<SalvarLogViaRabbitCommand>(), It.IsAny<CancellationToken>()), Times.Once);
+        }
+    }
+}


### PR DESCRIPTION
Implementa o worker para consolidação dos dados do sondagem para os indicadores das 10 ues com estudantes não alfabéticos o painel educacional, incluindo nova tabela SQL, entidade de domínio, repositório, caso de uso, comando, consulta, mapeamento e registro de dependências. Adiciona testes relacionados e integra-se ao RabbitMQ para processamento em segundo plano. Permite a recuperação e o armazenamento de dados de consolidação de alfabetização crítica do serviço Sondagem.