### PR TITLE
Adiciona AnoLetivo para consolidacao nivel escrita

### DIFF
--- a/src/SME.SGP.Aplicacao/Commands/PainelEducacional/SalvarConsolidacaoNivelEscritaAlfabetizacao/SalvarConsolidacaoNivelEscritaAlfabetizacaoPainelEducacionalCommandHandler.cs
+++ b/src/SME.SGP.Aplicacao/Commands/PainelEducacional/SalvarConsolidacaoNivelEscritaAlfabetizacao/SalvarConsolidacaoNivelEscritaAlfabetizacaoPainelEducacionalCommandHandler.cs
@@ -44,7 +44,8 @@ namespace SME.SGP.Aplicacao.Commands.PainelEducacional.SalvarConsolidacaoNivelEs
             NivelEscrita = dto.NivelEscrita,
             Periodo = dto.Periodo,
             Quantidade = dto.QuantidadeAlunos,
-            UeCodigo = dto.UeCodigo
+            UeCodigo = dto.UeCodigo,
+            AnoLetivo = short.Parse(dto.AnoLetivo)
         };
     }
 }


### PR DESCRIPTION
Inclui a propriedade AnoLetivo, ao criar o DTO de consolidação nivel escrita. Isso garante que o ano letivo seja definido corretamente durante a operação de salvamento.