### PR TITLE
Adicionar lógica de abreviação do nome Dre e atualizar o uso

### DIFF
--- a/src/SME.SGP.Aplicacao/Commands/PainelEducacional/SalvarConsolidacaoAlfabetizacaoCriticaEscrita/SalvarConsolidacaoAlfabetizacaoCriticaEscritaCommandHandler.cs
+++ b/src/SME.SGP.Aplicacao/Commands/PainelEducacional/SalvarConsolidacaoAlfabetizacaoCriticaEscrita/SalvarConsolidacaoAlfabetizacaoCriticaEscritaCommandHandler.cs
@@ -1,6 +1,7 @@
 ﻿using MediatR;
 using SME.SGP.Dominio.Entidades;
 using SME.SGP.Dominio.Interfaces.Repositorios;
+using SME.SGP.Infra;
 using SME.SGP.Infra.Dtos.Sondagem;
 using System;
 using System.Collections.Generic;
@@ -55,12 +56,13 @@ namespace SME.SGP.Aplicacao.Commands.PainelEducacional.SalvarConsolidacaoAlfabet
             foreach (var itemWithIndex in dtoOrdenado.Select((item, i) => new { Item = item, Index = i }))
             {
                 var ue = ues.FirstOrDefault(u => u.CodigoUe == itemWithIndex.Item.UeCodigo && u.Dre.CodigoDre == itemWithIndex.Item.DreCodigo);
+                var ueShortName = ue.TipoEscola.ShortName();
                 resultado.Add(new ConsolidacaoAlfabetizacaoCriticaEscrita()
                 {
                     DreCodigo = itemWithIndex.Item.DreCodigo,
                     UeCodigo = itemWithIndex.Item.UeCodigo,
-                    DreNome = ue.Dre.Nome,
-                    UeNome = ue.Nome,
+                    DreNome = ue.Dre.PrefixoDoNomeAbreviado,
+                    UeNome = $"{ueShortName} {ue.Nome}",
                     PercentualTotalAlunos = itemWithIndex.Item.PercentualNaoAlfabetizados,
                     TotalAlunosNaoAlfabetizados = itemWithIndex.Item.QuantidadeNaoAlfabetizados,
                     Posicao = itemWithIndex.Index + 1

--- a/src/SME.SGP.Dados/Mapeamentos/DreMap.cs
+++ b/src/SME.SGP.Dados/Mapeamentos/DreMap.cs
@@ -13,6 +13,7 @@ namespace SME.SGP.Dados.Mapeamentos
             Map(c => c.DataAtualizacao).ToColumn("data_atualizacao");
             Map(c => c.Id).ToColumn("id").IsIdentity().IsKey();
             Map(c => c.Nome).ToColumn("nome");
+            Map(c => c.PrefixoDoNomeAbreviado).Ignore();
         }
     }
 }

--- a/src/SME.SGP.Dominio/Entidades/Dre.cs
+++ b/src/SME.SGP.Dominio/Entidades/Dre.cs
@@ -1,9 +1,7 @@
 ﻿using System;
-using System.Diagnostics.CodeAnalysis;
 
 namespace SME.SGP.Dominio
 {
-    [ExcludeFromCodeCoverage]
     public class Dre
     {
         public string Abreviacao { get; set; }
@@ -11,5 +9,17 @@ namespace SME.SGP.Dominio
         public DateTime DataAtualizacao { get; set; }
         public long Id { get; set; }
         public string Nome { get; set; }
+
+        public string PrefixoDoNomeAbreviado
+        {
+            get
+            {
+                string novaSigla = "DRE";
+                string textoParaSubstituir = "DIRETORIA REGIONAL DE EDUCACAO";
+                var nomeFormatado = Nome.ToUpper().Replace(textoParaSubstituir, novaSigla).Trim();
+                return nomeFormatado;
+            }
+            private set { }
+        }
     }
 }

--- a/teste/SME.SGP.Aplicacao.Teste/Commands/PainelEducacional/SalvarConsolidacaoAlfabetizacaoCriticaEscritaCommandHandlerTeste.cs
+++ b/teste/SME.SGP.Aplicacao.Teste/Commands/PainelEducacional/SalvarConsolidacaoAlfabetizacaoCriticaEscritaCommandHandlerTeste.cs
@@ -57,9 +57,9 @@ namespace SME.SGP.Aplicacao.Teste.Commands.PainelEducacional
 
             var uesRetorno = new List<Ue>
             {
-                new() { CodigoUe = "UE1", Nome = "EMEF UE 1", Dre = new Dre { CodigoDre = "DRE1", Nome = "DRE UM" } },
-                new() { CodigoUe = "UE2", Nome = "EMEF UE 2", Dre = new Dre { CodigoDre = "DRE2", Nome = "DRE DOIS" } },
-                new() { CodigoUe = "UE3", Nome = "EMEF UE 3", Dre = new Dre { CodigoDre = "DRE2", Nome = "DRE DOIS" } }
+                new() { CodigoUe = "UE1", Nome = "UE 1", TipoEscola = TipoEscola.EMEF, Dre = new Dre { CodigoDre = "DRE1", Nome = "DIRETORIA REGIONAL DE EDUCACAO UM" } },
+                new() { CodigoUe = "UE2", Nome = "UE 2", TipoEscola = TipoEscola.EMEF, Dre = new Dre { CodigoDre = "DRE2", Nome = "DIRETORIA REGIONAL DE EDUCACAO DOIS" } },
+                new() { CodigoUe = "UE3", Nome = "UE 3", TipoEscola = TipoEscola.EMEF, Dre = new Dre { CodigoDre = "DRE2", Nome = "DIRETORIA REGIONAL DE EDUCACAO DOIS" } }
             };
 
             _mediatorMock.Setup(m => m.Send(It.IsAny<ObterUesComDrePorCodigoUesQuery>(), It.IsAny<CancellationToken>()))

--- a/teste/SME.SGP.Dominio.Teste/DreTeste.cs
+++ b/teste/SME.SGP.Dominio.Teste/DreTeste.cs
@@ -1,0 +1,21 @@
+﻿using Xunit;
+
+namespace SME.SGP.Dominio.Teste
+{
+    public class DreTeste
+    {
+        [Fact]
+        public void PrefixoDoNomeAbreviado_DeveRetornarNomeAbreviadoCorretamente()
+        {
+            // Arrange
+            var dre = new Dre
+            {
+                Nome = "DIRETORIA REGIONAL DE EDUCACAO - SUL"
+            };
+            // Act
+            var resultado = dre.PrefixoDoNomeAbreviado;
+            // Assert
+            Assert.Equal("DRE - SUL", resultado);
+        }
+    }
+}


### PR DESCRIPTION
Introduz a propriedade PrefixoDoNomeAbreviado à entidade Dre para gerar nomes abreviados. Atualiza o manipulador de comandos e os testes relacionados para usar a nova propriedade, garantindo que os nomes das escolas sejam formatados com o prefixo correto. Adiciona um teste unitário para a lógica de abreviação.