### PR TITLE
Trata nome Dre vazio ou nulo em abreviação

### DIFF
--- a/src/SME.SGP.Dominio/Entidades/Dre.cs
+++ b/src/SME.SGP.Dominio/Entidades/Dre.cs
@@ -14,6 +14,9 @@ namespace SME.SGP.Dominio
         {
             get
             {
+                if(string.IsNullOrWhiteSpace(Nome))
+                    return Nome;
+
                 string novaSigla = "DRE";
                 string textoParaSubstituir = "DIRETORIA REGIONAL DE EDUCACAO";
                 var nomeFormatado = Nome.ToUpper().Replace(textoParaSubstituir, novaSigla).Trim();

--- a/teste/SME.SGP.Dominio.Teste/DreTeste.cs
+++ b/teste/SME.SGP.Dominio.Teste/DreTeste.cs
@@ -17,5 +17,22 @@ namespace SME.SGP.Dominio.Teste
             // Assert
             Assert.Equal("DRE - SUL", resultado);
         }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData(" ")]
+        [InlineData(null)]
+        public void PrefixoDoNomeAbreviado_DeveRetornarMesmoNome_QuandoNomeForNuloOuVazio(string nomeInvalido)
+        {
+            // Arrange
+            var dre = new Dre
+            {
+                Nome = nomeInvalido
+            };
+            // Act
+            var resultado = dre.PrefixoDoNomeAbreviado;
+            // Assert
+            Assert.Equal(nomeInvalido, resultado);
+        }
     }
 }


### PR DESCRIPTION
Dre.PrefixoDoNomeAbreviado foi atualizado para retornar o nome original quando for nulo, vazio ou com espaços em branco. Testes unitários foram adicionados para verificar o comportamento correto nesses casos.