### PR TITLE
fix: diferenciando telas de login signal R

### DIFF
--- a/src/SME.SGP.Notificacoes.Hub/NotificacaoHub.cs
+++ b/src/SME.SGP.Notificacoes.Hub/NotificacaoHub.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Security.Claims;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace SME.SGP.Notificacoes.Hub
@@ -23,6 +24,8 @@ namespace SME.SGP.Notificacoes.Hub
         private readonly ILogger<NotificacaoHub> logger;
 
         private readonly static List<string> listaUsuarios = new List<string>();
+        private static int _contagemSgp = 0;
+        private static int _contagemSondagem = 0;
 
         public NotificacaoHub(
             IEventoNotificacaoCriada eventoCriada,
@@ -136,7 +139,13 @@ namespace SME.SGP.Notificacoes.Hub
                     await Clients.Client(Context.ConnectionId).SendAsync("BloqueioUsuario", (posicaoFila + 1) - limiteConexoes);
                 }
 
-                logger.LogWarning($"Usuário conectado. ConnectionId: {Context.ConnectionId}. Total de conexões: {listaUsuarios.Count}/{limiteConexoes}.");
+                var loginSource = Context.GetHttpContext()?.Request.Query["loginSource"].FirstOrDefault() ?? "sgp";
+                if (loginSource == "sondagem")
+                    Interlocked.Increment(ref _contagemSondagem);
+                else
+                    Interlocked.Increment(ref _contagemSgp);
+
+                logger.LogWarning($"Usuário conectado. ConnectionId: {Context.ConnectionId}. Total de conexões: {listaUsuarios.Count}/{limiteConexoes}. LoginSource: {loginSource}. SGP: {_contagemSgp}. Sondagem: {_contagemSondagem}. Limite de conexões: {limiteConexoes}.");
             }
             catch (Exception ex)
             {
@@ -179,7 +188,13 @@ namespace SME.SGP.Notificacoes.Hub
                     });
                 }
 
-                logger.LogWarning($"Usuário desconectado. ConnectionId: {Context.ConnectionId}. Total de conexões: {listaUsuarios.Count}/{limiteConexoes}.");
+                var loginSource = Context.GetHttpContext()?.Request.Query["loginSource"].FirstOrDefault() ?? "sgp";
+                if (loginSource == "sondagem")
+                    Interlocked.Decrement(ref _contagemSondagem);
+                else
+                    Interlocked.Decrement(ref _contagemSgp);
+
+                logger.LogWarning($"Usuário desconectado. ConnectionId: {Context.ConnectionId}. Total de conexões: {listaUsuarios.Count}/{limiteConexoes}. LoginSource: {loginSource}. SGP: {_contagemSgp}. Sondagem: {_contagemSondagem}. Limite de conexões: {limiteConexoes}.");
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
SignalR não conseguia identificar acessos da nova e da antiga pagina de login (agora consegue)

[AB#150999](https://dev.azure.com/SME-Spassu/2adf9619-d33f-4f8f-9177-79a681b537e8/_workitems/edit/150999)