### PR TITLE
Fix/150169 limitar modalidade ue

### DIFF
--- a/SME.SGP.Api.Teste/Controllers/AbrangenciaControllerTeste.cs
+++ b/SME.SGP.Api.Teste/Controllers/AbrangenciaControllerTeste.cs
@@ -141,7 +141,7 @@ namespace SME.SGP.Api.Testes.Controllers
                 .ReturnsAsync(retornoMediator);
 
             // Act
-            var resultado = await _controller.ObterTurmas(mediatorMock.Object, codigoUe, Modalidade.Fundamental);
+            var resultado = await _controller.ObterTurmas(mediatorMock.Object, codigoUe, new FiltroTurmasPorUeRequestDto{Modalidade = Modalidade.Fundamental});
 
             // Assert
             Assert.IsType<OkObjectResult>(resultado);

--- a/src/SME.SGP.Api/Controllers/AbrangenciaController.cs
+++ b/src/SME.SGP.Api/Controllers/AbrangenciaController.cs
@@ -227,22 +227,21 @@ namespace SME.SGP.Api.Controllers
         [ProducesResponseType(401)]
         [ProducesResponseType(typeof(RetornoBaseDto), 500)]
         [ProducesResponseType(typeof(RetornoBaseDto), 601)]
-        public async Task<IActionResult> ObterUes([FromServices] IObterUEsPorDreUseCase useCase, string codigoDre, [FromQuery] Modalidade? modalidade, [FromQuery] int periodo = 0, [FromQuery] int anoLetivo = 0, [FromQuery] bool consideraNovasUEs = false, [FromQuery] bool filtrarTipoEscolaPorAnoLetivo = false, string filtro = "")
+        public async Task<IActionResult> ObterUes([FromServices] IObterUEsPorDreUseCase useCase, string codigoDre, [FromQuery] FiltroUEsPorDreRequestDto request)
         {
-
-            if (filtro.Length < 3)
-                filtro = "";
+            var filtro = request.Filtro?.Length < 3 ? "" : request.Filtro;
 
             var dto = new UEsPorDreDto()
             {
                 CodigoDre = codigoDre,
-                Modalidade = modalidade,
-                Periodo = periodo,
-                AnoLetivo = anoLetivo,
-                ConsideraNovasUEs = consideraNovasUEs,
-                FiltrarTipoEscolaPorAnoLetivo = filtrarTipoEscolaPorAnoLetivo,
+                Modalidade = request.Modalidade,
+                Periodo = request.Periodo,
+                AnoLetivo = request.AnoLetivo,
+                ConsideraNovasUEs = request.ConsideraNovasUEs,
+                FiltrarTipoEscolaPorAnoLetivo = request.FiltrarTipoEscolaPorAnoLetivo,
                 Filtro = filtro,
-                ConsideraHistorico = ConsideraHistorico
+                ConsideraHistorico = ConsideraHistorico,
+                AnosTurma = request.AnosTurma
             };
 
             var ues = await useCase.Executar(dto);

--- a/src/SME.SGP.Api/Controllers/AbrangenciaController.cs
+++ b/src/SME.SGP.Api/Controllers/AbrangenciaController.cs
@@ -160,11 +160,20 @@ namespace SME.SGP.Api.Controllers
         [ProducesResponseType(401)]
         [ProducesResponseType(typeof(RetornoBaseDto), 500)]
         [ProducesResponseType(typeof(RetornoBaseDto), 601)]
-        public async Task<IActionResult> ObterTurmas([FromServices] IMediator mediator, string codigoUe, [FromQuery] Modalidade modalidade, int periodo = 0, [FromQuery] int anoLetivo = 0, [FromQuery] int[] tipos = null, [FromQuery] bool consideraNovosAnosInfantil = false)
+        public async Task<IActionResult> ObterTurmas([FromServices] IMediator mediator, string codigoUe, [FromQuery] FiltroTurmasPorUeRequestDto request)
         {
-            var turmas = await mediator.Send(
-                new ObterAbrangenciaTurmasPorUeModalidadePeriodoHistoricoAnoLetivoTiposQuery(codigoUe, modalidade,
-                    periodo, ConsideraHistorico, anoLetivo, tipos, consideraNovosAnosInfantil)); 
+            
+            var dto = new ObterAbrangenciaTurmasPorUeModalidadePeriodoHistoricoAnoLetivoTiposQuery(
+                codigoUe,
+                request.Modalidade,
+                request.Periodo, 
+                ConsideraHistorico, 
+                request.AnoLetivo, 
+                request.Tipos,
+                request.ConsideraNovosAnosInfantil, 
+                request.AnosTurma);
+            
+            var turmas = await mediator.Send(dto);
 
             if (!turmas.Any())
                 return NoContent();

--- a/src/SME.SGP.Aplicacao/Queries/Abrangencia/ObterAbrangenciaTurmasPorUeModalidadePeriodoHistoricoAnoLetivoTipos/ObterAbrangenciaTurmaQueryHandler.cs
+++ b/src/SME.SGP.Aplicacao/Queries/Abrangencia/ObterAbrangenciaTurmasPorUeModalidadePeriodoHistoricoAnoLetivoTipos/ObterAbrangenciaTurmaQueryHandler.cs
@@ -37,7 +37,7 @@ namespace SME.SGP.Aplicacao
 
             var result = await repositorioAbrangencia.ObterTurmasPorTipos(request.CodigoUe, login, perfil,
                 request.Modalidade, request.Tipos.NaoEhNulo() && request.Tipos.Any() ? request.Tipos : null, request.Periodo,
-                request.ConsideraHistorico, request.AnoLetivo, anosInfantilDesconsiderar);
+                request.ConsideraHistorico, request.AnoLetivo, anosInfantilDesconsiderar, request.AnosTurma);
 
             // Com base no codigo das turmas listada, é feito uma busca na Api Eol que está atualizada. 
             var codigosTurmas = result?.Select(t => t.Codigo.ToString())?.ToList();

--- a/src/SME.SGP.Aplicacao/Queries/Abrangencia/ObterAbrangenciaTurmasPorUeModalidadePeriodoHistoricoAnoLetivoTipos/ObterAbrangenciaTurmasPorUeModalidadePeriodoHistoricoAnoLetivoTiposQuery.cs
+++ b/src/SME.SGP.Aplicacao/Queries/Abrangencia/ObterAbrangenciaTurmasPorUeModalidadePeriodoHistoricoAnoLetivoTipos/ObterAbrangenciaTurmasPorUeModalidadePeriodoHistoricoAnoLetivoTiposQuery.cs
@@ -9,7 +9,7 @@ namespace SME.SGP.Aplicacao
 {
     public class ObterAbrangenciaTurmasPorUeModalidadePeriodoHistoricoAnoLetivoTiposQuery : IRequest<IEnumerable<AbrangenciaTurmaRetorno>>
     {
-        public ObterAbrangenciaTurmasPorUeModalidadePeriodoHistoricoAnoLetivoTiposQuery(string codigoUe, Modalidade modalidade, int periodo, bool consideraHistorico, int anoLetivo, int[] tipos, bool consideraNovosAnosInfantil = false)
+        public ObterAbrangenciaTurmasPorUeModalidadePeriodoHistoricoAnoLetivoTiposQuery(string codigoUe, Modalidade modalidade, int periodo, bool consideraHistorico, int anoLetivo, int[] tipos, bool consideraNovosAnosInfantil = false, string[] anosTurma = null)
         {
             CodigoUe = codigoUe;
             Modalidade = modalidade;
@@ -18,6 +18,7 @@ namespace SME.SGP.Aplicacao
             AnoLetivo = anoLetivo;
             Tipos = tipos;
             ConsideraNovosAnosInfantil = consideraNovosAnosInfantil;
+            AnosTurma = anosTurma;
         }
 
         public string CodigoUe { get; set; }
@@ -27,6 +28,7 @@ namespace SME.SGP.Aplicacao
         public int AnoLetivo { get; set; }
         public int[] Tipos { get; set; }
         public bool ConsideraNovosAnosInfantil { get; set; }
+        public string[] AnosTurma { get; set; }
     }
     public class ObterAbrangenciaTurmasPorUeModalidadePeriodoHistoricoAnoLetivoTiposQueryValidator : AbstractValidator<ObterAbrangenciaTurmasPorUeModalidadePeriodoHistoricoAnoLetivoTiposQuery>
     {

--- a/src/SME.SGP.Aplicacao/Queries/UE/ObterUEsPorDRE/ObterUEsPorDREQuery.cs
+++ b/src/SME.SGP.Aplicacao/Queries/UE/ObterUEsPorDRE/ObterUEsPorDREQuery.cs
@@ -24,6 +24,7 @@ namespace SME.SGP.Aplicacao
             FiltrarTipoEscolaPorAnoLetivo = dto.FiltrarTipoEscolaPorAnoLetivo;
             Filtro = dto.Filtro;
             FiltroEhCodigo = !string.IsNullOrWhiteSpace(dto.Filtro) && dto.Filtro.All(char.IsDigit);
+            AnosTurma = dto.AnosTurma;
         }
         public ObterUEsPorDREQuery(string codigoDre, string login, Guid perfil, bool consideraHistorico, int anoLetivo)
         {
@@ -51,6 +52,7 @@ namespace SME.SGP.Aplicacao
         public bool FiltrarTipoEscolaPorAnoLetivo { get; }
         public string Filtro { get; }
         public bool FiltroEhCodigo { get; }
+        public string[] AnosTurma { get; }
     }
 
     public class ObterUEsPorDREQueryValidator : AbstractValidator<ObterUEsPorDREQuery>

--- a/src/SME.SGP.Aplicacao/Queries/UE/ObterUEsPorDRE/ObterUEsPorDREQueryHandler.cs
+++ b/src/SME.SGP.Aplicacao/Queries/UE/ObterUEsPorDRE/ObterUEsPorDREQueryHandler.cs
@@ -27,7 +27,7 @@ namespace SME.SGP.Aplicacao.Queries.UE.ObterUEsPorDRE
             var parametroNovosTiposUE = await mediator.Send(new ObterNovosTiposUEPorAnoQuery(anoNovosTiposUE));
             var novosTiposUE = parametroNovosTiposUE?.Split(',').Select(a => int.Parse(a)).ToArray();
 
-            var ues = await repositorioAbrangencia.ObterUes(request.CodigoDre, request.Login, request.Perfil, request.Modalidade, request.Periodo, request.ConsideraHistorico, request.AnoLetivo, novosTiposUE, request.Filtro, request.FiltroEhCodigo);
+            var ues = await repositorioAbrangencia.ObterUes(request.CodigoDre, request.Login, request.Perfil, request.Modalidade, request.Periodo, request.ConsideraHistorico, request.AnoLetivo, novosTiposUE, request.Filtro, request.FiltroEhCodigo, request.AnosTurma);
 
             if (request.FiltrarTipoEscolaPorAnoLetivo && request.AnoLetivo <= 2020)
                 ues = ues.Where(u => !u.EhInfantil);

--- a/src/SME.SGP.Dados/Repositorios/RepositorioAbrangencia.cs
+++ b/src/SME.SGP.Dados/Repositorios/RepositorioAbrangencia.cs
@@ -848,9 +848,11 @@ namespace SME.SGP.Dados.Repositorios
             return await database.Conexao.QueryAsync<Abrangencia>(query, new { usuarioId });
         }
 
-        public async Task<IEnumerable<AbrangenciaTurmaRetorno>> ObterTurmasPorTipos(string codigoUe, string login, Guid perfil, Modalidade modalidade, int[] tipos, int periodo = 0, bool consideraHistorico = false, int anoLetivo = 0, string[] anosInfantilDesconsiderar = null)
+        public async Task<IEnumerable<AbrangenciaTurmaRetorno>> ObterTurmasPorTipos(string codigoUe, string login, Guid perfil, Modalidade modalidade, int[] tipos, int periodo = 0, bool consideraHistorico = false, int anoLetivo = 0, string[] anosInfantilDesconsiderar = null, string[] anosTurma = null)
         {
-            var query = @"select ano,
+            var temFiltroAnosTurma = anosTurma != null && anosTurma.Any();
+
+            var query = new StringBuilder(@"select ano,
                                  anoLetivo,
                                  codigo,
                                  codigoModalidade,
@@ -861,18 +863,22 @@ namespace SME.SGP.Dados.Repositorios
                                  ensinoEspecial,
                                  turma_id as id,
                                  tipoturma,
-                                 nome_filtro as nomeFiltro 
-                            from f_abrangencia_turmas_tipos(@login, @perfil, @consideraHistorico, @modalidade, @semestre, @codigoUe, @anoLetivo, @tipos, @anosInfantilDesconsiderar)
-                          order by 5";
+                                 nome_filtro as nomeFiltro
+                            from f_abrangencia_turmas_tipos(@login, @perfil, @consideraHistorico, @modalidade, @semestre, @codigoUe, @anoLetivo, @tipos, @anosInfantilDesconsiderar)");
+
+            if (temFiltroAnosTurma)
+                query.AppendLine("where ano = any(@anosTurma)");
+
+            query.AppendLine("order by 5");
 
             var resultado = await database.Conexao
-                .QueryAsync<AbrangenciaTurmaRetorno>(query.ToString(), new { login, perfil, consideraHistorico, modalidade, semestre = periodo, codigoUe, anoLetivo, tipos, anosInfantilDesconsiderar });
+                .QueryAsync<AbrangenciaTurmaRetorno>(query.ToString(), new { login, perfil, consideraHistorico, modalidade, semestre = periodo, codigoUe, anoLetivo, tipos, anosInfantilDesconsiderar, anosTurma });
 
             var resultadoFiltrado = resultado.GroupBy(x => x.Codigo).SelectMany(y => y.OrderBy(a => a.Codigo).Take(1));
 
             if (perfil == Perfis.PERFIL_SUPERVISOR)
             {
-                resultadoFiltrado = await AcrescentarTurmasSupervisor(login, modalidade, periodo, codigoUe, consideraHistorico, anoLetivo, resultadoFiltrado);
+                resultadoFiltrado = await AcrescentarTurmasSupervisor(login, modalidade, periodo, codigoUe, consideraHistorico, anoLetivo, resultadoFiltrado, anosTurma);
 
                 if (tipos.NaoEhNulo() && tipos.Any())
                     resultadoFiltrado = resultadoFiltrado.Where(r => tipos.Contains(r.TipoTurma));
@@ -1137,7 +1143,7 @@ namespace SME.SGP.Dados.Repositorios
             return retorno;
         }
 
-        private async Task<IEnumerable<AbrangenciaTurmaRetorno>> AcrescentarTurmasSupervisor(string login, Modalidade modalidade, int semestre, string ue, bool consideraHistorico, int anoLetivo, IEnumerable<AbrangenciaTurmaRetorno> retorno)
+        private async Task<IEnumerable<AbrangenciaTurmaRetorno>> AcrescentarTurmasSupervisor(string login, Modalidade modalidade, int semestre, string ue, bool consideraHistorico, int anoLetivo, IEnumerable<AbrangenciaTurmaRetorno> retorno, string[] anosTurma = null)
         {
             var dadosAbrangenciaSupervisor =
                 await ObterDadosAbrangenciaSupervisor(login, consideraHistorico, anoLetivo);
@@ -1150,6 +1156,7 @@ namespace SME.SGP.Dados.Repositorios
                                             where (Modalidade)da.Modalidade == modalidade &&
                                                   da.CodigoUe == ue &&
                                                   (semestre == 0 || (semestre > 0 && da.Semestre == semestre)) &&
+                                                  (anosTurma == null || !anosTurma.Any() || anosTurma.Contains(da.TurmaAno)) &&
                                                   !turmas.Contains(da.TurmaId)
                                             select new AbrangenciaTurmaRetorno
                                             {

--- a/src/SME.SGP.Dados/Repositorios/RepositorioAbrangencia.cs
+++ b/src/SME.SGP.Dados/Repositorios/RepositorioAbrangencia.cs
@@ -455,7 +455,7 @@ namespace SME.SGP.Dados.Repositorios
             return (await database.Conexao.QueryFirstOrDefaultAsync<AbrangenciaUeRetorno>(query.ToString(), new { codigo, login, perfil }));
         }
 
-        public async Task<IEnumerable<AbrangenciaUeRetorno>> ObterUes(string codigoDre, string login, Guid perfil, Modalidade? modalidade = null, int periodo = 0, bool consideraHistorico = false, int anoLetivo = 0, int[] ignorarTiposUE = null, string filtro = "", bool filtroEhCodigo = false)
+        public async Task<IEnumerable<AbrangenciaUeRetorno>> ObterUes(string codigoDre, string login, Guid perfil, Modalidade? modalidade = null, int periodo = 0, bool consideraHistorico = false, int anoLetivo = 0, int[] ignorarTiposUE = null, string filtro = "", bool filtroEhCodigo = false, string[] anosTurma = null)
         {
             var query = new StringBuilder();
 
@@ -463,22 +463,32 @@ namespace SME.SGP.Dados.Repositorios
             query.AppendLine("nome as NomeSimples,");
             query.AppendLine("tipoescola,");
             query.AppendLine("ue_id as id");
-            query.AppendLine("from f_abrangencia_ues(@login, @perfil, @consideraHistorico, @modalidade, @semestre, @codigoDre, @anoLetivo, @ignorarTiposUE)");
+            query.AppendLine("from f_abrangencia_ues(@login, @perfil, @consideraHistorico, @modalidade, @semestre, @codigoDre, @anoLetivo, @ignorarTiposUE) f");
 
-            if (!string.IsNullOrWhiteSpace(filtro))
+            var temFiltroTexto = !string.IsNullOrWhiteSpace(filtro);
+            var temFiltroAnosTurma = anosTurma != null && anosTurma.Any();
+
+            var condicoes = new List<string>();
+
+            if (temFiltroTexto)
             {
                 filtro = $"%{filtro.ToUpper()}%";
-
-                if (filtroEhCodigo)
-                    query.AppendLine("where upper(codigo) like @filtro");
-                else
-                    query.AppendLine("where upper(nome) like @filtro");
-
-                query.AppendLine("order by 2");
-                query.AppendLine("limit 10;");
+                condicoes.Add(filtroEhCodigo ? "upper(codigo) like @filtro" : "upper(nome) like @filtro");
             }
-            else
-                query.AppendLine("order by 2;");
+
+            if (temFiltroAnosTurma)
+                condicoes.Add(@"exists (
+                    select 1 from turma t
+                    where t.ue_id = f.ue_id
+                      and t.ano = any(@anosTurma)
+                      and t.ano_letivo = @anoLetivo
+                      and not t.historica
+                )");
+
+            if (condicoes.Any())
+                query.AppendLine("where " + string.Join(" and ", condicoes));
+
+            query.AppendLine(temFiltroTexto ? "order by 2 limit 10;" : "order by 2;");
 
             var parametros = new
             {
@@ -490,7 +500,8 @@ namespace SME.SGP.Dados.Repositorios
                 codigoDre,
                 anoLetivo,
                 ignorarTiposUE,
-                filtro
+                filtro,
+                anosTurma
             };
 
             var retorno = await database.Conexao
@@ -498,8 +509,8 @@ namespace SME.SGP.Dados.Repositorios
 
             if (perfil == Perfis.PERFIL_SUPERVISOR)
             {
-                retorno = await AcrescentarUesSupervisor(login, modalidade ?? 0, periodo, codigoDre, consideraHistorico, anoLetivo, ignorarTiposUE, retorno);
-                if (!string.IsNullOrWhiteSpace(filtro))
+                retorno = await AcrescentarUesSupervisor(login, modalidade ?? 0, periodo, codigoDre, consideraHistorico, anoLetivo, ignorarTiposUE, retorno, anosTurma);
+                if (temFiltroTexto)
                 {
                     filtro = filtro.Replace("%", string.Empty);
                     retorno = filtroEhCodigo ?
@@ -987,7 +998,7 @@ namespace SME.SGP.Dados.Repositorios
             return retorno;
         }
 
-        private async Task<IEnumerable<AbrangenciaUeRetorno>> AcrescentarUesSupervisor(string login, Modalidade modalidade, int semestre, string dre, bool consideraHistorico, int anoLetivo, int[] tiposEscolasIgnoradas, IEnumerable<AbrangenciaUeRetorno> retorno)
+        private async Task<IEnumerable<AbrangenciaUeRetorno>> AcrescentarUesSupervisor(string login, Modalidade modalidade, int semestre, string dre, bool consideraHistorico, int anoLetivo, int[] tiposEscolasIgnoradas, IEnumerable<AbrangenciaUeRetorno> retorno, string[] anosTurma = null)
         {
             var retornoUesSupervisor = new List<AbrangenciaUeRetorno>();   
             var dadosAbrangenciaSupervisor =
@@ -1006,8 +1017,9 @@ namespace SME.SGP.Dados.Repositorios
                     uesComplementares = (from da in dadosAbrangenciaSupervisor
                                          where (Modalidade)da.Modalidade == modalidade &&
                                                da.CodigoDre == dre &&
-                                               !tiposEscolasIgnoradas.Contains((int)da.TipoEscola) &&
+                                               (tiposEscolasIgnoradas == null || !tiposEscolasIgnoradas.Contains((int)da.TipoEscola)) &&
                                                (semestre == 0 || (semestre > 0 && da.Semestre == semestre)) &&
+                                               (anosTurma == null || !anosTurma.Any() || anosTurma.Contains(da.TurmaAno)) &&
                                                !ues.Contains(da.UeId)
                                          select new
                                          {
@@ -1021,8 +1033,9 @@ namespace SME.SGP.Dados.Repositorios
                 {
                     uesComplementares = (from da in dadosAbrangenciaSupervisor
                                          where da.CodigoDre == dre &&
-                                               !tiposEscolasIgnoradas.Contains((int)da.TipoEscola) &&
+                                               (tiposEscolasIgnoradas == null || !tiposEscolasIgnoradas.Contains((int)da.TipoEscola)) &&
                                                (semestre == 0 || (semestre > 0 && da.Semestre == semestre)) &&
+                                               (anosTurma == null || !anosTurma.Any() || anosTurma.Contains(da.TurmaAno)) &&
                                                !ues.Contains(da.UeId)
                                          select new
                                          {

--- a/src/SME.SGP.Dominio.Interfaces/Repositorios/IRepositorioAbrangencia.cs
+++ b/src/SME.SGP.Dominio.Interfaces/Repositorios/IRepositorioAbrangencia.cs
@@ -68,7 +68,7 @@ namespace SME.SGP.Dominio.Interfaces
 
         Task<IEnumerable<OpcaoDropdownDto>> ObterDropDownTurmasPorUeAnoLetivoModalidadeSemestreAnos(string codigoUe, int anoLetivo, Modalidade? modalidade, int semestre, IList<string> anos);
         Task<IEnumerable<Abrangencia>> ObterAbrangenciaGeralPorUsuarioId(long usuarioId);
-        Task<IEnumerable<AbrangenciaTurmaRetorno>> ObterTurmasPorTipos(string codigoUe, string login, Guid perfil, Modalidade modalidade, int[] tipos, int periodo = 0, bool consideraHistorico = false, int anoLetivo = 0, string[] anosInfantilDesconsiderar = null);
+        Task<IEnumerable<AbrangenciaTurmaRetorno>> ObterTurmasPorTipos(string codigoUe, string login, Guid perfil, Modalidade modalidade, int[] tipos, int periodo = 0, bool consideraHistorico = false, int anoLetivo = 0, string[] anosInfantilDesconsiderar = null, string[] anosTurma = null);
         Task<IEnumerable<DropdownTurmaRetornoDto>> ObterTurmasPorAnoLetivoUeModalidadeSemestreEAnosEscolares(int anoLetivo, string codigoUe, int[] modalidades, int semestre, string[] anos, bool historico);
         Task<IEnumerable<string>> ObterLoginsAbrangenciaUePorPerfil(long ueId, Guid perfil, bool historica = false);
         Task<IEnumerable<string>> ObterProfessoresTurmaPorAbrangencia(string turmaCodigo);

--- a/src/SME.SGP.Dominio.Interfaces/Repositorios/IRepositorioAbrangencia.cs
+++ b/src/SME.SGP.Dominio.Interfaces/Repositorios/IRepositorioAbrangencia.cs
@@ -47,7 +47,7 @@ namespace SME.SGP.Dominio.Interfaces
         Task<AbrangenciaUeRetorno> ObterUe(string codigo, string login, Guid perfil);
         Task<bool> UsuarioPossuiAbrangenciaAdm(long usuarioId);
 
-        Task<IEnumerable<AbrangenciaUeRetorno>> ObterUes(string codigoDre, string login, Guid perfil, Modalidade? modalidade = null, int periodo = 0, bool consideraHistorico = false, int anoLetivo = 0, int[] ignorarTiposUE = null, string filtro = "", bool filtroEhCodigo = false);
+        Task<IEnumerable<AbrangenciaUeRetorno>> ObterUes(string codigoDre, string login, Guid perfil, Modalidade? modalidade = null, int periodo = 0, bool consideraHistorico = false, int anoLetivo = 0, int[] ignorarTiposUE = null, string filtro = "", bool filtroEhCodigo = false, string[] anosTurma = null);
 
         Task<IEnumerable<AbrangenciaUeComDreRetorno>> ObterUesPorListaDres(string[] codigosDres, string login, Guid perfil, Modalidade? modalidade = null, int periodo = 0, bool consideraHistorico = false, int anoLetivo = 0, int[] ignorarTiposUE = null);
 

--- a/src/SME.SGP.Infra/Dtos/FiltroTurmasPorUeRequestDto.cs
+++ b/src/SME.SGP.Infra/Dtos/FiltroTurmasPorUeRequestDto.cs
@@ -1,0 +1,14 @@
+using SME.SGP.Dominio;
+
+namespace SME.SGP.Infra.Dtos
+{
+    public record FiltroTurmasPorUeRequestDto
+    {
+        public Modalidade Modalidade { get; init; }
+        public int Periodo { get; init; } = 0;
+        public int AnoLetivo { get; init; } = 0;
+        public int[] Tipos { get; init; }
+        public bool ConsideraNovosAnosInfantil { get; init; } = false;
+        public string[] AnosTurma { get; init; }
+    }
+}

--- a/src/SME.SGP.Infra/Dtos/FiltroUEsPorDreRequestDto.cs
+++ b/src/SME.SGP.Infra/Dtos/FiltroUEsPorDreRequestDto.cs
@@ -1,0 +1,15 @@
+using SME.SGP.Dominio;
+
+namespace SME.SGP.Infra.Dtos
+{
+    public class FiltroUEsPorDreRequestDto
+    {
+        public Modalidade? Modalidade { get; set; }
+        public int Periodo { get; set; } = 0;
+        public int AnoLetivo { get; set; } = 0;
+        public bool ConsideraNovasUEs { get; set; } = false;
+        public bool FiltrarTipoEscolaPorAnoLetivo { get; set; } = false;
+        public string Filtro { get; set; } = "";
+        public string[] AnosTurma { get; set; }
+    }
+}

--- a/src/SME.SGP.Infra/Dtos/UEsPorDreDto.cs
+++ b/src/SME.SGP.Infra/Dtos/UEsPorDreDto.cs
@@ -12,5 +12,6 @@ namespace SME.SGP.Infra.Dtos
         public bool ConsideraNovasUEs { get; set; }
         public bool FiltrarTipoEscolaPorAnoLetivo { get; set; }
         public string Filtro { get; set; }
+        public string[] AnosTurma { get; set; }
     }
 }

--- a/teste/SME.SGP.TesteIntegracao/Abrangencia/Ao_filtrar_turmas_por_anos_turma.cs
+++ b/teste/SME.SGP.TesteIntegracao/Abrangencia/Ao_filtrar_turmas_por_anos_turma.cs
@@ -1,0 +1,148 @@
+using MediatR;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Newtonsoft.Json;
+using Shouldly;
+using SME.SGP.Aplicacao;
+using SME.SGP.Dominio;
+using SME.SGP.Dto;
+using SME.SGP.Infra;
+using SME.SGP.Infra.Dtos;
+using SME.SGP.TesteIntegracao.Abrangencia.Base;
+using SME.SGP.TesteIntegracao.Setup;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace SME.SGP.TesteIntegracao.Abrangencia
+{
+    public class Ao_filtrar_turmas_por_anos_turma : AbrangenciaBase
+    {
+        public Ao_filtrar_turmas_por_anos_turma(CollectionFixture collectionFixture) : base(collectionFixture)
+        {
+        }
+
+        private void ConfigurarFakeEol()
+        {
+            var turmasEolFake = new List<TurmaApiEolDto>
+            {
+                new TurmaApiEolDto { Codigo = int.Parse(TURMA_CODIGO_1) }
+            };
+
+            var jsonResposta = JsonConvert.SerializeObject(turmasEolFake);
+            var conteudoHttp = new StringContent(jsonResposta, System.Text.Encoding.UTF8, "application/json");
+
+            var urlApiEol = ServiceProvider.GetService<IConfiguration>()["UrlApiEOL"];
+            RegistradorDependenciasTeste.HttpHandlerFake.AdicionarCenario(urlApiEol, HttpStatusCode.OK, conteudoHttp);
+        }
+
+        // Cria DRE/UE/turma (turma com ano = ANO_7) e concede abrangência direta ao usuário (perfil comum).
+        private async Task CriarCenarioComTurmaAno7PerfilComum()
+        {
+            ConfigurarFakeEol();
+
+            var filtro = new FiltroTesteDto()
+            {
+                Perfil = ObterPerfilPOA_Portugues(),
+                AnoTurma = ANO_7,
+                Modalidade = Modalidade.Medio,
+                TipoCalendario = ModalidadeTipoCalendario.FundamentalMedio
+            };
+
+            await CriarDadosBase(filtro);
+
+            await InserirNaBase(new Dominio.Abrangencia()
+            {
+                UsuarioId = USUARIO_ID_1,
+                Perfil = Guid.Parse(PerfilUsuario.POA_LINGUA_PORTUGUESA.Name()),
+                DreId = DRE_ID_1
+            });
+        }
+
+        // Cria DRE/UE/turma (turma com ano = ANO_7) e concede a abrangência via supervisor_escola_dre,
+        // forçando o resultado a vir pelo caminho de AcrescentarTurmasSupervisor (filtro em memória).
+        private async Task CriarCenarioComTurmaAno7PerfilSupervisor()
+        {
+            ConfigurarFakeEol();
+
+            var filtro = new FiltroTesteDto()
+            {
+                Perfil = Guid.Parse(PerfilUsuario.SUPERVISOR.Name()).ToString(),
+                AnoTurma = ANO_7,
+                Modalidade = Modalidade.Medio,
+                TipoCalendario = ModalidadeTipoCalendario.FundamentalMedio
+            };
+
+            await CriarDadosBase(filtro);
+
+            await InserirNaBase(new SupervisorEscolaDre()
+            {
+                DreId = DRE_CODIGO_1,
+                EscolaId = UE_CODIGO_1,
+                SupervisorId = USUARIO_PROFESSOR_LOGIN_2222222,
+                Tipo = (int)TipoResponsavelAtribuicao.SupervisorEscolar,
+                CriadoEm = DateTime.Now,
+                CriadoPor = "Teste",
+                CriadoRF = USUARIO_PROFESSOR_LOGIN_2222222,
+                Excluido = false
+            });
+        }
+
+        private Task<IEnumerable<AbrangenciaTurmaRetorno>> ObterTurmas(string[] anosTurma)
+        {
+            var mediator = ServiceProvider.GetService<IMediator>();
+
+            return mediator.Send(
+                new ObterAbrangenciaTurmasPorUeModalidadePeriodoHistoricoAnoLetivoTiposQuery(
+                    UE_CODIGO_1, Modalidade.Medio, 0, false, DateTime.Now.Year, null, false, anosTurma));
+        }
+
+        [Fact(DisplayName = "Abrangência - ObterTurmas não deve retornar turma cujo ano não está na lista de anosTurma informada (perfil comum)")]
+        public async Task Nao_deve_retornar_turma_de_ano_fora_do_filtro_anosTurma_perfil_comum()
+        {
+            await CriarCenarioComTurmaAno7PerfilComum();
+
+            var turmas = await ObterTurmas(new[] { ANO_1, ANO_2, ANO_3 });
+
+            turmas.ShouldBeEmpty();
+        }
+
+        [Fact(DisplayName = "Abrangência - ObterTurmas deve retornar turma cujo ano está na lista de anosTurma informada (perfil comum)")]
+        public async Task Deve_retornar_turma_de_ano_dentro_do_filtro_anosTurma_perfil_comum()
+        {
+            await CriarCenarioComTurmaAno7PerfilComum();
+
+            var turmas = await ObterTurmas(new[] { ANO_7 });
+
+            turmas.ShouldNotBeNull();
+            turmas.Count().ShouldBe(1);
+            turmas.First().Id.ShouldBe(TURMA_ID_1);
+        }
+
+        [Fact(DisplayName = "Abrangência - ObterTurmas não deve retornar turma cujo ano não está na lista de anosTurma informada (perfil supervisor)")]
+        public async Task Nao_deve_retornar_turma_de_ano_fora_do_filtro_anosTurma_perfil_supervisor()
+        {
+            await CriarCenarioComTurmaAno7PerfilSupervisor();
+
+            var turmas = await ObterTurmas(new[] { ANO_1, ANO_2, ANO_3 });
+
+            turmas.ShouldBeEmpty();
+        }
+
+        [Fact(DisplayName = "Abrangência - ObterTurmas deve retornar turma cujo ano está na lista de anosTurma informada (perfil supervisor)")]
+        public async Task Deve_retornar_turma_de_ano_dentro_do_filtro_anosTurma_perfil_supervisor()
+        {
+            await CriarCenarioComTurmaAno7PerfilSupervisor();
+
+            var turmas = await ObterTurmas(new[] { ANO_7 });
+
+            turmas.ShouldNotBeNull();
+            turmas.Count().ShouldBe(1);
+            turmas.First().Id.ShouldBe(TURMA_ID_1);
+        }
+    }
+}

--- a/teste/SME.SGP.TesteIntegracao/Abrangencia/Ao_filtrar_ues_por_anos_turma.cs
+++ b/teste/SME.SGP.TesteIntegracao/Abrangencia/Ao_filtrar_ues_por_anos_turma.cs
@@ -2,11 +2,13 @@ using Microsoft.Extensions.DependencyInjection;
 using Shouldly;
 using SME.SGP.Aplicacao.Interfaces;
 using SME.SGP.Dominio;
+using SME.SGP.Dto;
 using SME.SGP.Infra;
 using SME.SGP.Infra.Dtos;
 using SME.SGP.TesteIntegracao.Abrangencia.Base;
 using SME.SGP.TesteIntegracao.Setup;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
@@ -19,8 +21,8 @@ namespace SME.SGP.TesteIntegracao.Abrangencia
         {
         }
 
-        [Fact(DisplayName = "Abrangência - Obter ues filtrando por anos de turma, perfil comum")]
-        public async Task Ao_obter_ues_filtrando_por_anos_turma_perfil_comum()
+        // Cria DRE/UE/turma (turma com ano = ANO_7) e concede abrangência direta ao usuário (perfil comum).
+        private async Task CriarCenarioComTurmaAno7PerfilComum()
         {
             var filtro = new FiltroTesteDto()
             {
@@ -38,36 +40,11 @@ namespace SME.SGP.TesteIntegracao.Abrangencia
                 Perfil = Guid.Parse(PerfilUsuario.POA_LINGUA_PORTUGUESA.Name()),
                 DreId = DRE_ID_1
             });
-
-            var useCase = ServiceProvider.GetService<IObterUEsPorDreUseCase>();
-
-            var dtoSemCorrespondencia = new UEsPorDreDto()
-            {
-                CodigoDre = DRE_CODIGO_1,
-                AnoLetivo = DateTime.Now.Year,
-                Modalidade = Modalidade.Medio,
-                AnosTurma = new[] { ANO_1, ANO_2, ANO_3 }
-            };
-
-            var uesSemCorrespondencia = await useCase.Executar(dtoSemCorrespondencia);
-            uesSemCorrespondencia.ShouldBeEmpty();
-
-            var dtoComCorrespondencia = new UEsPorDreDto()
-            {
-                CodigoDre = DRE_CODIGO_1,
-                AnoLetivo = DateTime.Now.Year,
-                Modalidade = Modalidade.Medio,
-                AnosTurma = new[] { ANO_7 }
-            };
-
-            var uesComCorrespondencia = await useCase.Executar(dtoComCorrespondencia);
-            uesComCorrespondencia.ShouldNotBeNull();
-            uesComCorrespondencia.Count().ShouldBe(1);
-            uesComCorrespondencia.First().Id.ShouldBe(UE_ID_1);
         }
 
-        [Fact(DisplayName = "Abrangência - Obter ues filtrando por anos de turma, perfil supervisor")]
-        public async Task Ao_obter_ues_filtrando_por_anos_turma_perfil_supervisor()
+        // Cria DRE/UE/turma (turma com ano = ANO_7) e concede a abrangência via supervisor_escola_dre,
+        // forçando o resultado a vir pelo caminho de AcrescentarUesSupervisor (filtro em memória).
+        private async Task CriarCenarioComTurmaAno7PerfilSupervisor()
         {
             var filtro = new FiltroTesteDto()
             {
@@ -90,32 +67,63 @@ namespace SME.SGP.TesteIntegracao.Abrangencia
                 CriadoRF = USUARIO_PROFESSOR_LOGIN_2222222,
                 Excluido = false
             });
+        }
 
+        private Task<IEnumerable<AbrangenciaUeRetorno>> ObterUes(string[] anosTurma)
+        {
             var useCase = ServiceProvider.GetService<IObterUEsPorDreUseCase>();
 
-            var dtoSemCorrespondencia = new UEsPorDreDto()
+            return useCase.Executar(new UEsPorDreDto()
             {
                 CodigoDre = DRE_CODIGO_1,
                 AnoLetivo = DateTime.Now.Year,
                 Modalidade = Modalidade.Medio,
-                AnosTurma = new[] { ANO_1, ANO_2, ANO_3 }
-            };
+                AnosTurma = anosTurma
+            });
+        }
 
-            var uesSemCorrespondencia = await useCase.Executar(dtoSemCorrespondencia);
-            uesSemCorrespondencia.ShouldBeEmpty();
+        [Fact(DisplayName = "Abrangência - ObterUes não deve retornar UE cuja turma não está na lista de anosTurma informada (perfil comum)")]
+        public async Task Nao_deve_retornar_ue_de_turma_fora_do_filtro_anosTurma_perfil_comum()
+        {
+            await CriarCenarioComTurmaAno7PerfilComum();
 
-            var dtoComCorrespondencia = new UEsPorDreDto()
-            {
-                CodigoDre = DRE_CODIGO_1,
-                AnoLetivo = DateTime.Now.Year,
-                Modalidade = Modalidade.Medio,
-                AnosTurma = new[] { ANO_7 }
-            };
+            var ues = await ObterUes(new[] { ANO_1, ANO_2, ANO_3 });
 
-            var uesComCorrespondencia = await useCase.Executar(dtoComCorrespondencia);
-            uesComCorrespondencia.ShouldNotBeNull();
-            uesComCorrespondencia.Count().ShouldBe(1);
-            uesComCorrespondencia.First().Id.ShouldBe(UE_ID_1);
+            ues.ShouldBeEmpty();
+        }
+
+        [Fact(DisplayName = "Abrangência - ObterUes deve retornar UE cuja turma está na lista de anosTurma informada (perfil comum)")]
+        public async Task Deve_retornar_ue_de_turma_dentro_do_filtro_anosTurma_perfil_comum()
+        {
+            await CriarCenarioComTurmaAno7PerfilComum();
+
+            var ues = await ObterUes(new[] { ANO_7 });
+
+            ues.ShouldNotBeNull();
+            ues.Count().ShouldBe(1);
+            ues.First().Id.ShouldBe(UE_ID_1);
+        }
+
+        [Fact(DisplayName = "Abrangência - ObterUes não deve retornar UE cuja turma não está na lista de anosTurma informada (perfil supervisor)")]
+        public async Task Nao_deve_retornar_ue_de_turma_fora_do_filtro_anosTurma_perfil_supervisor()
+        {
+            await CriarCenarioComTurmaAno7PerfilSupervisor();
+
+            var ues = await ObterUes(new[] { ANO_1, ANO_2, ANO_3 });
+
+            ues.ShouldBeEmpty();
+        }
+
+        [Fact(DisplayName = "Abrangência - ObterUes deve retornar UE cuja turma está na lista de anosTurma informada (perfil supervisor)")]
+        public async Task Deve_retornar_ue_de_turma_dentro_do_filtro_anosTurma_perfil_supervisor()
+        {
+            await CriarCenarioComTurmaAno7PerfilSupervisor();
+
+            var ues = await ObterUes(new[] { ANO_7 });
+
+            ues.ShouldNotBeNull();
+            ues.Count().ShouldBe(1);
+            ues.First().Id.ShouldBe(UE_ID_1);
         }
     }
 }

--- a/teste/SME.SGP.TesteIntegracao/Abrangencia/Ao_filtrar_ues_por_anos_turma.cs
+++ b/teste/SME.SGP.TesteIntegracao/Abrangencia/Ao_filtrar_ues_por_anos_turma.cs
@@ -1,0 +1,121 @@
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using SME.SGP.Aplicacao.Interfaces;
+using SME.SGP.Dominio;
+using SME.SGP.Infra;
+using SME.SGP.Infra.Dtos;
+using SME.SGP.TesteIntegracao.Abrangencia.Base;
+using SME.SGP.TesteIntegracao.Setup;
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace SME.SGP.TesteIntegracao.Abrangencia
+{
+    public class Ao_filtrar_ues_por_anos_turma : AbrangenciaBase
+    {
+        public Ao_filtrar_ues_por_anos_turma(CollectionFixture collectionFixture) : base(collectionFixture)
+        {
+        }
+
+        [Fact(DisplayName = "Abrangência - Obter ues filtrando por anos de turma, perfil comum")]
+        public async Task Ao_obter_ues_filtrando_por_anos_turma_perfil_comum()
+        {
+            var filtro = new FiltroTesteDto()
+            {
+                Perfil = ObterPerfilPOA_Portugues(),
+                AnoTurma = ANO_7,
+                Modalidade = Modalidade.Medio,
+                TipoCalendario = ModalidadeTipoCalendario.FundamentalMedio
+            };
+
+            await CriarDadosBase(filtro);
+
+            await InserirNaBase(new Dominio.Abrangencia()
+            {
+                UsuarioId = USUARIO_ID_1,
+                Perfil = Guid.Parse(PerfilUsuario.POA_LINGUA_PORTUGUESA.Name()),
+                DreId = DRE_ID_1
+            });
+
+            var useCase = ServiceProvider.GetService<IObterUEsPorDreUseCase>();
+
+            var dtoSemCorrespondencia = new UEsPorDreDto()
+            {
+                CodigoDre = DRE_CODIGO_1,
+                AnoLetivo = DateTime.Now.Year,
+                Modalidade = Modalidade.Medio,
+                AnosTurma = new[] { ANO_1, ANO_2, ANO_3 }
+            };
+
+            var uesSemCorrespondencia = await useCase.Executar(dtoSemCorrespondencia);
+            uesSemCorrespondencia.ShouldBeEmpty();
+
+            var dtoComCorrespondencia = new UEsPorDreDto()
+            {
+                CodigoDre = DRE_CODIGO_1,
+                AnoLetivo = DateTime.Now.Year,
+                Modalidade = Modalidade.Medio,
+                AnosTurma = new[] { ANO_7 }
+            };
+
+            var uesComCorrespondencia = await useCase.Executar(dtoComCorrespondencia);
+            uesComCorrespondencia.ShouldNotBeNull();
+            uesComCorrespondencia.Count().ShouldBe(1);
+            uesComCorrespondencia.First().Id.ShouldBe(UE_ID_1);
+        }
+
+        [Fact(DisplayName = "Abrangência - Obter ues filtrando por anos de turma, perfil supervisor")]
+        public async Task Ao_obter_ues_filtrando_por_anos_turma_perfil_supervisor()
+        {
+            var filtro = new FiltroTesteDto()
+            {
+                Perfil = Guid.Parse(PerfilUsuario.SUPERVISOR.Name()).ToString(),
+                AnoTurma = ANO_7,
+                Modalidade = Modalidade.Medio,
+                TipoCalendario = ModalidadeTipoCalendario.FundamentalMedio
+            };
+
+            await CriarDadosBase(filtro);
+
+            await InserirNaBase(new SupervisorEscolaDre()
+            {
+                DreId = DRE_CODIGO_1,
+                EscolaId = UE_CODIGO_1,
+                SupervisorId = USUARIO_PROFESSOR_LOGIN_2222222,
+                Tipo = (int)TipoResponsavelAtribuicao.SupervisorEscolar,
+                CriadoEm = DateTime.Now,
+                CriadoPor = "Teste",
+                CriadoRF = USUARIO_PROFESSOR_LOGIN_2222222,
+                Excluido = false
+            });
+
+            var useCase = ServiceProvider.GetService<IObterUEsPorDreUseCase>();
+
+            var dtoSemCorrespondencia = new UEsPorDreDto()
+            {
+                CodigoDre = DRE_CODIGO_1,
+                AnoLetivo = DateTime.Now.Year,
+                Modalidade = Modalidade.Medio,
+                AnosTurma = new[] { ANO_1, ANO_2, ANO_3 }
+            };
+
+            var uesSemCorrespondencia = await useCase.Executar(dtoSemCorrespondencia);
+            uesSemCorrespondencia.ShouldBeEmpty();
+
+            var dtoComCorrespondencia = new UEsPorDreDto()
+            {
+                CodigoDre = DRE_CODIGO_1,
+                AnoLetivo = DateTime.Now.Year,
+                Modalidade = Modalidade.Medio,
+                AnosTurma = new[] { ANO_7 }
+            };
+
+            var uesComCorrespondencia = await useCase.Executar(dtoComCorrespondencia);
+            uesComCorrespondencia.ShouldNotBeNull();
+            uesComCorrespondencia.Count().ShouldBe(1);
+            uesComCorrespondencia.First().Id.ShouldBe(UE_ID_1);
+        }
+    }
+}


### PR DESCRIPTION
Adicionado parâmetro de AnosTurma nos endpoints:

ObterUE: retornar somente UEs que contenham as turmas enviadas (no caso da sondagem em ensino fundamental, o front vai enviar 1, 2 e 3)

ObterTurmas: retornar somente as turmas dos anos solicitado (no caso de ensino fundamental, o front vai enviar anos 1, 2 e 3)


Também foi inserido novos testes para validar os parâmetros.