### PR TITLE
Fix/152854 fechamento conselho classe consolidado

### DIFF
--- a/src/SME.SGP.Aplicacao/Commands/ConsolidacaoConselhoClasse/SalvarCacheConselhoClasseOuFechamentoNotaConceito/SalvarCacheConselhoClasseOuFechamentoNotaConceitoCommandHandler.cs
+++ b/src/SME.SGP.Aplicacao/Commands/ConsolidacaoConselhoClasse/SalvarCacheConselhoClasseOuFechamentoNotaConceito/SalvarCacheConselhoClasseOuFechamentoNotaConceitoCommandHandler.cs
@@ -51,7 +51,7 @@ namespace SME.SGP.Aplicacao
                 retornoCacheMapeado.ConceitoIdConselhoClasse = request.ConceitoId;
             }
 
-            await repositorioCache.SalvarAsync(nomeChaveCache, retornoCacheMapeado, 5);
+            await repositorioCache.SalvarAsync(nomeChaveCache, retornoCacheMapeado, 20);
             return true;
         }
     }

--- a/src/SME.SGP.Metrica.Worker/Repositorios/RepositorioSGPConsulta.cs
+++ b/src/SME.SGP.Metrica.Worker/Repositorios/RepositorioSGPConsulta.cs
@@ -279,7 +279,8 @@ namespace SME.SGP.Metrica.Worker.Repositorios
                                                                                  and tmp.bimestre = coalesce(cccatn.bimestre, 0) and tmp.disciplina_id::int8 = cccatn.componente_curricular_id
                 where tmp.sequencia = 1
                       and coalesce(coalesce(tmp.nota_conselho_classe_fechamento, tmp.conceito_id_conselho_classe_fechamento), 0)
-                          <> coalesce(coalesce(cccatn.nota, cccatn.conceito_id), 0);", new { ueId });
+                          <> coalesce(coalesce(cccatn.nota, cccatn.conceito_id), 0);", new { ueId },
+                commandTimeout: 300);
 
         public Task<IEnumerable<FrequenciaAlunoInconsistente>> ObterFrequenciaAlunoInconsistente(long turmaId)
             => database.Conexao.QueryAsync<FrequenciaAlunoInconsistente>(


### PR DESCRIPTION
Aumentar tempo de cache das notas salvas no conselho de classe para possíveis lentidões no sistema em grande uso

Aumentar o timeout na query executada pelo worker para sincronizar as notas dos alunos

[152854](https://dev.azure.com/SME-Spassu/SME%20-%20Sustenta%C3%A7%C3%A3o/_workitems/edit/152854)