### PR TITLE
otimização query ObterConselhosClasseNaoConsolidados

### DIFF
--- a/src/SME.SGP.Metrica.Worker/Repositorios/RepositorioSGPConsulta.cs
+++ b/src/SME.SGP.Metrica.Worker/Repositorios/RepositorioSGPConsulta.cs
@@ -205,10 +205,10 @@ namespace SME.SGP.Metrica.Worker.Repositorios
                            inner join conselho_classe cc on ft.id = cc.fechamento_turma_id and not cc.excluido
                            inner join conselho_classe_aluno cca on cc.id = cca.conselho_classe_id and not cca.excluido
                            inner join fechamento_aluno fa on ftd.id = fa.fechamento_turma_disciplina_id and fa.aluno_codigo = cca.aluno_codigo and not fa.excluido
-                           inner join fechamento_nota fn on fa.id = fn.fechamento_aluno_id and not fn.excluido 
+                           inner join fechamento_nota fn on fa.id = fn.fechamento_aluno_id and not fn.excluido
                            where t.ano_letivo >= extract(year from NOW()) -1
                                                    and u.id = @ueId
-                           union                       
+                           union all
                            select cca.id as conselho_classe_aluno_id,
                            ccn.componente_curricular_codigo as disciplina_id
                            from fechamento_turma ft
@@ -221,7 +221,7 @@ namespace SME.SGP.Metrica.Worker.Repositorios
                            where t.ano_letivo >= extract(year from NOW()) -1
                                                    and u.id = @ueId),
                   vw_notas_conceitos_ue as
-                      (select distinct t.id turma_id,
+                      (select t.id turma_id,
                         t.turma_id codigo_turma,
                         coalesce(cca.aluno_codigo, fa.aluno_codigo) aluno_codigo,
                         coalesce(pe.bimestre, 0) as bimestre,


### PR DESCRIPTION
otimização da query ObterConselhosClasseNaoConsolidados

remoção do distinct e substituição de union para union all, visto que no final é feito um where com sequencia  = 1, que já realiza o processo de diferenciar.


[152854](https://dev.azure.com/SME-Spassu/SME%20-%20Sustenta%C3%A7%C3%A3o/_workitems/edit/152854)