### PR TITLE
hotfix  #153233 Ocultando Relatório Analítico

### DIFF
--- a/ETL/CoreSSO/153233 - Desativa Relatorio Analitico Sondagem.sql
+++ b/ETL/CoreSSO/153233 - Desativa Relatorio Analitico Sondagem.sql
@@ -1,0 +1,22 @@
+BEGIN TRY
+    BEGIN TRAN
+    PRINT 'Desativação Relatório Analítico Sondagem - INÍCIO'
+
+    UPDATE gp
+    SET gp.grp_consultar = 0
+    FROM CoreSSO.dbo.SYS_GrupoPermissao gp
+    INNER JOIN CoreSSO.dbo.SYS_Modulo m 
+        ON gp.mod_id = m.mod_id 
+       AND gp.sis_id = m.sis_id
+    WHERE m.mod_nome = 'Relatório Analítico Sondagem';
+
+    PRINT 'Desativação Relatório Analítico Sondagem - FIM'
+
+    COMMIT TRAN
+END TRY
+BEGIN CATCH
+    PRINT 'Erro ao desativar permissionamento'
+    IF (@@TRANCOUNT > 0)
+        ROLLBACK TRAN;
+END CATCH
+GO


### PR DESCRIPTION
Adiciona script SQL para desativar a permissão de consulta (grp_consultar) do módulo "Relatório Analítico Sondagem" na tabela SYS_GrupoPermissao