### PR TITLE
obter ues ignora dre supervisor

### DIFF
--- a/scripts/V774__CRIACAO_VIEW_ABRANGENCIA_NIVEL_DRE_COMPLETA.sql
+++ b/scripts/V774__CRIACAO_VIEW_ABRANGENCIA_NIVEL_DRE_COMPLETA.sql
@@ -1,0 +1,11 @@
+CREATE OR REPLACE VIEW public.v_abrangencia_nivel_dre_completa
+AS SELECT DISTINCT a.dre_id,
+    a.perfil AS perfil_id,
+    a.historico,
+    u.login,
+    a.ue_id,
+    a.turma_id
+   FROM abrangencia a
+     JOIN usuario u ON a.usuario_id = u.id
+  WHERE a.dre_id IS NOT NULL AND a.ue_id IS NULL AND a.turma_id IS NULL
+  ORDER BY a.dre_id;

--- a/scripts/V775__AJUSTE_FUNCAO_ABRANGENCIA_DRES_NIVEL_DRE_COMPLETA.sql
+++ b/scripts/V775__AJUSTE_FUNCAO_ABRANGENCIA_DRES_NIVEL_DRE_COMPLETA.sql
@@ -1,0 +1,55 @@
+CREATE OR REPLACE FUNCTION public.f_abrangencia_dres(p_login character varying, p_perfil_id uuid, p_historico boolean, p_modalidade_codigo integer DEFAULT 0, p_turma_semestre integer DEFAULT 0, p_ano_letivo integer DEFAULT 0)
+ RETURNS SETOF v_estrutura_abrangencia_dres
+ LANGUAGE sql
+AS $function$
+select distinct act.dre_abreviacao,
+				act.dre_codigo,
+                act.dre_nome,
+                act.modalidade_codigo,
+                act.dre_id as id
+	from v_abrangencia_nivel_dre_completa a
+		inner join v_abrangencia_cadeia_turmas act
+			on a.dre_id = act.dre_id
+where a.login = p_login and
+	  a.perfil_id = p_perfil_id and
+	  act.turma_historica = p_historico and
+      (p_modalidade_codigo = 0 or (p_modalidade_codigo <> 0 and act.modalidade_codigo = p_modalidade_codigo)) and
+      (p_turma_semestre = 0 or (p_turma_semestre <> 0 and act.turma_semestre = p_turma_semestre)) and
+      (p_ano_letivo = 0 or (p_ano_letivo <> 0 and act.turma_ano_letivo = p_ano_letivo))
+
+union
+
+select distinct act.dre_abreviacao,
+				act.dre_codigo,
+                act.dre_nome,
+                act.modalidade_codigo,
+                act.dre_id
+	from v_abrangencia_nivel_ue a
+		inner join v_abrangencia_cadeia_turmas act
+			on a.ue_id = act.ue_id
+where a.login = p_login and
+	  a.perfil_id = p_perfil_id and
+	  act.turma_historica = p_historico and
+      (p_modalidade_codigo = 0 or (p_modalidade_codigo <> 0 and act.modalidade_codigo = p_modalidade_codigo)) and
+      (p_turma_semestre = 0 or (p_turma_semestre <> 0 and act.turma_semestre = p_turma_semestre)) and
+      (p_ano_letivo = 0 or (p_ano_letivo <> 0 and act.turma_ano_letivo = p_ano_letivo))
+
+union
+
+select distinct act.dre_abreviacao,
+				act.dre_codigo,
+                act.dre_nome,
+                act.modalidade_codigo,
+                act.dre_id
+	from v_abrangencia_nivel_turma a
+		inner join v_abrangencia_cadeia_turmas act
+			on a.turma_id = act.turma_id
+where a.login = p_login and
+	  a.perfil_id = p_perfil_id and
+	  ((p_historico = true and a.historico = true) or
+	   (p_historico = false and a.historico  = false and act.turma_historica = false)) and
+      (p_modalidade_codigo = 0 or (p_modalidade_codigo <> 0 and act.modalidade_codigo = p_modalidade_codigo)) and
+      (p_turma_semestre = 0 or (p_turma_semestre <> 0 and act.turma_semestre = p_turma_semestre)) and
+      (p_ano_letivo = 0 or (p_ano_letivo <> 0 and act.turma_ano_letivo = p_ano_letivo));
+$function$
+;

--- a/scripts/V776__AJUSTE_VIEW_ABRANGENCIA_NIVEL_DRE_SUPERVISOR.sql
+++ b/scripts/V776__AJUSTE_VIEW_ABRANGENCIA_NIVEL_DRE_SUPERVISOR.sql
@@ -1,0 +1,12 @@
+CREATE OR REPLACE VIEW public.v_abrangencia_nivel_dre
+AS SELECT DISTINCT a.dre_id,
+    a.perfil AS perfil_id,
+    a.historico,
+    u.login,
+    a.ue_id,
+    a.turma_id
+   FROM abrangencia a
+     JOIN usuario u ON a.usuario_id = u.id
+  WHERE a.dre_id IS NOT NULL AND a.ue_id IS NULL AND a.turma_id IS NULL
+    AND a.perfil <> '4ee1e074-37d6-e911-abd6-f81654fe895d' -- Supervisor
+  ORDER BY a.dre_id;


### PR DESCRIPTION
Ignorar linhas da abrangência quando for perfil supervisor e ter somente dres no retorno das UEs

[AZ:153346](https://dev.azure.com/SME-Spassu/SME%20-%20Sustenta%C3%A7%C3%A3o/_workitems/edit/153346)