### PR TITLE
Fix/153528 ajustes cj atualizar abrangencia

### DIFF
--- a/scripts/V778__CORRECAO_ABRANGENCIA_HISTORICA_PROFESSOR_CJ.sql
+++ b/scripts/V778__CORRECAO_ABRANGENCIA_HISTORICA_PROFESSOR_CJ.sql
@@ -1,6 +1,5 @@
 update abrangencia a
-   set historico      = true,
-       dt_fim_vinculo = coalesce(a.dt_fim_vinculo, t.data_atualizacao::date, now()::date)
+   set historico      = true
   from turma t
  where t.id = a.turma_id
    and a.historico = false

--- a/scripts/V778__CORRECAO_ABRANGENCIA_HISTORICA_PROFESSOR_CJ.sql
+++ b/scripts/V778__CORRECAO_ABRANGENCIA_HISTORICA_PROFESSOR_CJ.sql
@@ -1,0 +1,10 @@
+update abrangencia a
+   set historico      = true,
+       dt_fim_vinculo = coalesce(a.dt_fim_vinculo, t.data_atualizacao::date, now()::date)
+  from turma t
+ where t.id = a.turma_id
+   and a.historico = false
+   and t.historica = true
+   and t.ano_letivo = 2026
+   and a.perfil in ('41e1e074-37d6-e911-abd6-f81654fe895d',   -- Professor CJ
+                    '61e1e074-37d6-e911-abd6-f81654fe895d');  -- Professor CJ Ed. Infantil

--- a/src/SME.SGP.Aplicacao/Servicos/ServicoAbrangencia.cs
+++ b/src/SME.SGP.Aplicacao/Servicos/ServicoAbrangencia.cs
@@ -208,12 +208,13 @@ namespace SME.SGP.Aplicacao.Servicos
 
                     if (turmaId > 0)
                     {
-                        var abragenciaSGP = abrangenciaGeralSGP.FirstOrDefault(a => a.TurmaId == turmaId && !a.Historico);
-                        if (abragenciaSGP.NaoEhNulo())
+
+                        var abrangenciasSGP = abrangenciaGeralSGP.Where(a => a.TurmaId == turmaId && !a.Historico);
+                        if (abrangenciasSGP.Any())
                         {
-                            var virouHistorica = await mediator.Send(new VerificaSeTurmaVirouHistoricaQuery(abragenciaSGP.TurmaId.Value));
-                            if (virouHistorica && !abragenciaSGP.Historico)
-                                paraAtualizarAbrangencia.Add(abragenciaSGP);
+                            var virouHistorica = await mediator.Send(new VerificaSeTurmaVirouHistoricaQuery(turmaId));
+                            if (virouHistorica)
+                                paraAtualizarAbrangencia.AddRange(abrangenciasSGP);
                         }
 
                         await repositorioAbrangencia.AtualizaAbrangenciaHistoricaAnosAnteriores(paraAtualizarAbrangencia.Select(x => x.Id), anoLetivo);

--- a/src/SME.SGP.Aplicacao/Servicos/ServicoAbrangencia.cs
+++ b/src/SME.SGP.Aplicacao/Servicos/ServicoAbrangencia.cs
@@ -196,6 +196,9 @@ namespace SME.SGP.Aplicacao.Servicos
 
                     var paraAtualizar = abrangenciaGeralSGP.Where(x => abrangenciaTurmasHistoricasEOL.Any(ath => ath.DreId == x.DreId && ath.UeId == x.UeId && ath.TurmaId == x.TurmaId && ath.UsuarioId == x.UsuarioId));
 
+                    if (turmaId > 0 && await mediator.Send(new VerificaSeTurmaVirouHistoricaQuery(turmaId)))
+                        paraAtualizar = paraAtualizar.Concat(abrangenciaGeralSGP.Where(a => a.TurmaId == turmaId && !a.Historico &&
+                                                                                           (a.Perfil == Perfis.PERFIL_CJ || a.Perfil == Perfis.PERFIL_CJ_INFANTIL)));
 
                     await repositorioAbrangencia.AtualizaAbrangenciaHistorica(paraAtualizar.Select(x => x.Id));
                 }

--- a/src/SME.SGP.Aplicacao/Servicos/ServicoAbrangencia.cs
+++ b/src/SME.SGP.Aplicacao/Servicos/ServicoAbrangencia.cs
@@ -194,11 +194,12 @@ namespace SME.SGP.Aplicacao.Servicos
 
                     abrangenciaGeralSGP = await repositorioAbrangencia.ObterAbrangenciaGeralPorUsuarioId(usuario.Id);
 
-                    var paraAtualizar = abrangenciaGeralSGP.Where(x => abrangenciaTurmasHistoricasEOL.Any(ath => ath.DreId == x.DreId && ath.UeId == x.UeId && ath.TurmaId == x.TurmaId && ath.UsuarioId == x.UsuarioId));
+                    var turmaInformadaVirouHistorica = turmaId > 0 && await mediator.Send(new VerificaSeTurmaVirouHistoricaQuery(turmaId));
 
-                    if (turmaId > 0 && await mediator.Send(new VerificaSeTurmaVirouHistoricaQuery(turmaId)))
-                        paraAtualizar = paraAtualizar.Concat(abrangenciaGeralSGP.Where(a => a.TurmaId == turmaId && !a.Historico &&
-                                                                                           (a.Perfil == Perfis.PERFIL_CJ || a.Perfil == Perfis.PERFIL_CJ_INFANTIL)));
+                    var paraAtualizar = abrangenciaGeralSGP.Where(x => abrangenciaTurmasHistoricasEOL.Any(ath => ath.DreId == x.DreId && ath.UeId == x.UeId && ath.TurmaId == x.TurmaId && ath.UsuarioId == x.UsuarioId)
+                                                                      || (turmaInformadaVirouHistorica && x.TurmaId == turmaId && !x.Historico &&
+                                                                          (x.Perfil == Perfis.PERFIL_CJ || x.Perfil == Perfis.PERFIL_CJ_INFANTIL))
+                                                                          );
 
                     await repositorioAbrangencia.AtualizaAbrangenciaHistorica(paraAtualizar.Select(x => x.Id));
                 }


### PR DESCRIPTION
[AZ153528](https://dev.azure.com/SME-Spassu/SME%20-%20Sustenta%C3%A7%C3%A3o/_boards/board/t/SME%20-%20Sustenta%C3%A7%C3%A3o%20Team/Hist%C3%B3ria%20de%20Usu%C3%A1rio?text=sgp&workitem=153528)


Por CJ terem somente turmas associadas, não estavam tendo suas turmas atualizadas como histórico, pois a comparação exigia DRE e UE, e também só estava sendo considerado turmas que vem do EOL, e CJ é cadastro exclusivo do SGP


Também esta sendo enviado um script para atualizar os CJ que ficaram fora de sincronização antes da correção (relação de usuários que vão ser afetados anexo ao bug)