### PR TITLE
Data fixa para o teste Deve_Incluir_Aluno_Ativo()

### DIFF
--- a/teste/SME.SGP.Aplicacao.Teste/CasosDeUso/Nota/ObterNotasParaAvaliacoesUseCaseTeste.cs
+++ b/teste/SME.SGP.Aplicacao.Teste/CasosDeUso/Nota/ObterNotasParaAvaliacoesUseCaseTeste.cs
@@ -1511,6 +1511,8 @@ namespace SME.SGP.Aplicacao.Teste.CasosDeUso.Nota
         {
             var filtro = new ListaNotasConceitosDto { TurmaHistorico = true };
             var alunoMock = CriarAlunoMock(ativo: true, situacao: SituacaoMatriculaAluno.Ativo);
+            alunoMock.DataMatricula = new DateTime(2026, 4, 27);
+            alunoMock.DataSituacao = new DateTime(2026, 7, 17);
             var alunos = new List<AlunoPorTurmaResposta> { alunoMock };
 
             var resultado = FiltrarAlunos(alunos, filtro);


### PR DESCRIPTION
Correção para o teste Deve_Incluir_Aluno_Ativo() para não se basear no dia atual e sim uma data fixa.